### PR TITLE
Another small edge case in DescriptiveStats

### DIFF
--- a/learn/src/main/scala/breeze/stats/DescriptiveStats.scala
+++ b/learn/src/main/scala/breeze/stats/DescriptiveStats.scala
@@ -37,7 +37,7 @@ object DescriptiveStats {
       val s = oldVar + frac.fromInt(i-1) / frac.fromInt(i) * d *d;
       (mu,s,i);
     }
-    (mu,s/frac.fromInt(n-1));
+    (mu,if(n==1) frac.zero else s/frac.fromInt(n-1));
   }
 
   /**

--- a/learn/src/test/scala/breeze/stats/DescriptiveStatsTest.scala
+++ b/learn/src/test/scala/breeze/stats/DescriptiveStatsTest.scala
@@ -2,12 +2,20 @@ package breeze.stats
 
 import org.scalatest.WordSpec
 import org.scalatest.matchers.ShouldMatchers
-class DescriptiveStatsTest extends WordSpec with ShouldMatchers{
-"The Percentile" should {
-  "not explode when p = 1" in {
-    val a = List.fill(100)(1.)
-    DescriptiveStats.percentile(a,1.) should be (1.)
+
+
+
+class DescriptiveStatsTest extends WordSpec with ShouldMatchers {
+  "DescriptiveStats" should {
+    "percentile should not explode when p = 1" in {
+      val a = List.fill(100)(1.0)
+      DescriptiveStats.percentile(a,1.) should be (1.0)
+    }
+    "variance should not explode when size of list is 1" in {
+      val a = List(1.)
+      DescriptiveStats.meanAndVariance(a) should be ((1.0,0))
+    }
   }
-}
+
 
 }


### PR DESCRIPTION
Probably better to return 0 as opposed to NaN. (i.e. Population Variance
as opposed to Standard Variance)
