### PR TITLE
Update build to fix compilation errors in learn project

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -67,10 +67,11 @@ object BreezeBuild extends Build {
   val opencsv = "net.sf.opencsv" % "opencsv" % "2.3"
   val logging = "com.typesafe" %% "scalalogging-log4j" % "1.0.1"
   val log4j =  "org.apache.logging.log4j" % "log4j-core" % "2.0-beta4"
+  val oldScalaActors = "org.scala-lang" % "scala-actors" % "2.10.0"
 
   val coreDeps = Seq(paranamer, opencsv, logging, log4j)
   val commonDeps = Seq(paranamer, netlib, jblas)
-  val learnDeps = commonDeps ++ Seq(liblinear)
+  val learnDeps = commonDeps ++ Seq(liblinear, oldScalaActors)
   val vizDeps = Seq(
     "jfree" % "jcommon" % "1.0.16",
     "jfree" % "jfreechart" % "1.0.13",


### PR DESCRIPTION
The old scala actors were deprecated with the 2.10 release. This pull request updates the build to specify a new dependency on the old scala actors (they were packaged into a separate jar in 2.10). Eventually we might want to consider moving to the new SIP-14 futures and Akka actors that are now part of 2.10.
