### PR TITLE
Fix CompactHessian constructor invocation.

### DIFF
--- a/src/main/scala/breeze/optimize/ProjectedQuasiNewton.scala
+++ b/src/main/scala/breeze/optimize/ProjectedQuasiNewton.scala
@@ -47,7 +47,7 @@ class CompactHessian(M: DenseMatrix[Double], Y: RingBuffer[DenseVector[Double]],
     val M = DenseMatrix.vertcat(DenseMatrix.horzcat(STS, L), DenseMatrix.horzcat(L.t, -D))
 
 
-    val newB = new CompactHessian(M, S, Y, sigma, m)
+    val newB = new CompactHessian(M, Y, S, sigma, m)
     newB
   }
 


### PR DESCRIPTION
Hi David,

the constructor invocation of CompactHessian in the ProjectedQuasiNewton algorithm passed arguments S and Y in the wrong order. We'll try to add some tests that expose the problem, but it would be good to pull that fix in as soon as possible (and maybe also push a new snapshot version).

Thanks and we'll be back with tests soon :)
  Martin
