### PR TITLE
Remove thread locals

### DIFF
--- a/src/main/scala/breeze/optimize/CachedDiffFunction.scala
+++ b/src/main/scala/breeze/optimize/CachedDiffFunction.scala
@@ -19,9 +19,11 @@ class CachedDiffFunction[T:CanCopy](obj: DiffFunction[T]) extends DiffFunction[T
 
   /** Calculates both the value and the gradient at a point */
   def calculate(x:T):(Double,T) = {
-    if(lastData == null || x != lastData._1) {
-      val newData = obj.calculate(x)
-      lastData = (copy(x), newData._1, newData._2)
+    this.synchronized {
+      if (lastData == null || x != lastData._1) {
+        val newData = obj.calculate(x)
+        lastData = (copy(x), newData._1, newData._2)
+      }
     }
 
     val (_, v, g) = lastData
@@ -44,9 +46,11 @@ class CachedBatchDiffFunction[T:CanCopy](obj: BatchDiffFunction[T]) extends Batc
 
   /** Calculates both the value and the gradient at a point */
   override def calculate(x:T, range: IndexedSeq[Int]):(Double,T) = {
-    if(lastData == null || range != lastData._4 || x != lastData._1) {
-      val newData = obj.calculate(x, range)
-      lastData = (copy(x), newData._1, newData._2, range)
+    this.synchronized {
+      if (lastData == null || range != lastData._4 || x != lastData._1) {
+        val newData = obj.calculate(x, range)
+        lastData = (copy(x), newData._1, newData._2, range)
+      }
     }
 
     val (_, v, g, _) = lastData


### PR DESCRIPTION
Hi David,

with regard to #97 is that how you meant it?
Are there any algorithms that evaluate the function in parallel?
If so, it might make more sense to use a SynchronizedMap[T, Double] so that the different threads don't overwrite the cache of all others.
If not, you could cherry-pick just 3bdaeb44285d12b46104f1256ea679fec845b143

Best
  Martin
