### PR TITLE
Add fast haar transformation (forward and inverse)

### DIFF
--- a/src/main/scala/breeze/signal/package.scala
+++ b/src/main/scala/breeze/signal/package.scala
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import breeze.signal.support.{CanFFT, CanIFFT}
+import breeze.signal.support.{CanFHT, CanIFHT}
 
 /**This package provides digital signal processing functions.
  *
@@ -52,5 +53,24 @@ package object signal {
     * @return
     */
   def ifft[Input, Output](v: Input)(implicit canIFFT: CanIFFT[Input, Output]): Output = canIFFT(v)
+
+  /**Return the padded fast haar transformation of a DenseVector or DenseMatrix. Note that
+   * the output will always be padded to a power of 2.</p>
+   * A matrix will cause a 2D fht. The 2D haar transformation is defined for squared power of 2
+   * matrices. A new matrix will thus be created and the old matrix will be placed in the upper-left
+   * part of the new matrix. Avoid calling this method with a matrix that has few cols / many rows or
+   * many cols / few rows (e.g. 1000000 x 3) as this will cause a very high memory consumption.
+   *
+   * @see https://en.wikipedia.org/wiki/Haar_wavelet
+   * @param v DenseVector or DenseMatrix to be transformed.
+   * @param canFHT implicit delegate which is used for implementation. End-users should not use this argument.
+   * @return DenseVector or DenseMatrix
+   */
+  def fht[Input, Output](v : Input)(implicit canFHT: CanFHT[Input, Output]): Output = canFHT(v)
+
+  /**Returns the inverse fast haar transform for a DenseVector or DenseMatrix.
+   *
+   */
+  def ifht[Input, Output](v : Input)(implicit canIFHT: CanIFHT[Input, Output]): Output = canIFHT(v)
 
 }

--- a/src/main/scala/breeze/signal/support/CanFHT.scala
+++ b/src/main/scala/breeze/signal/support/CanFHT.scala
@@ -1,0 +1,126 @@
+package breeze.signal.support
+
+import breeze.linalg.{DenseVector, DenseMatrix}
+
+/**
+ * Construction delegate for getting the FHT of a value of type InputType.
+ * Implementation details (especially
+ * option arguments) may be added in the future, so it is recommended not
+ * to call this implicit delegate directly.
+ *
+ * @author ktakagaki
+ */
+trait CanFHT[InputType, OutputType] {
+  def apply(v1: InputType): OutputType
+}
+
+/**
+ * Construction delegate for getting the FHT of a value of type InputType.
+ */
+object CanFHT {
+
+  // TODO: is the fht any good if you use complex numbers?
+  // the main computation (x + y) / 2, (x - y) / 2 would work with complex numbers
+  // but I can neither find a reference saying it would be a good idea nor a lib
+  // that uses it...
+
+  // TODO: Int/Long versions are easy as long as one does not need to normalize.
+  // The normalized version (deviding by 2 on each iteration) is recommended.
+  // However an unnormalized version could run on Int/Long vectors.
+
+  private val nFactor = 1d / Math.sqrt(2d)
+
+  /**Copy or pad a given vector.
+   */
+  private def padOrCopy(v : DenseVector[Double]) = {
+    if ((v.length & -v.length) == v.length) {
+      v.copy
+    } else {
+      val length = 1 << (32 - Integer.numberOfLeadingZeros(v.length))
+      val r = new DenseVector(new Array[Double](length))
+      r.slice(0, v.length) := v
+      r
+    }
+  }
+
+  /** Transform a matrix into a squared power of 2 matrix.
+   */
+  private def squareMatrix(m : DenseMatrix[Double]) : DenseMatrix[Double] = {
+    val maxd = Math.max(m.rows, m.cols)
+    val rows = if ((maxd & -maxd) == maxd) {
+      maxd
+    } else {
+      1 << (32 - Integer.numberOfLeadingZeros(Math.max(m.rows, m.cols)))
+    }
+    val o = DenseMatrix.zeros[Double](rows, rows)
+    for(r <- 0 until m.rows; c <- 0 until m.cols) {
+      o(r,c) = m(r,c)
+    }
+    o
+  }
+
+  /** Convert a dense matrix to a dense vector, concatenating all rows.
+   */
+  private def denseMatrixDToVector(m : DenseMatrix[Double]) : DenseVector[Double] = {
+    val v = new Array[Double](m.size)
+    for(r <- 0 until m.rows; c <- 0 until m.cols) {
+      val i = r * m.cols + c
+      if (i < v.length) v(i) = m(r,c)
+    }
+    new DenseVector[Double](v)
+  }
+  /** Shape a DenseVector as a matric with a given number of rows/cols.
+   */
+  private def denseVectorDToMatrix(v : DenseVector[Double], rows : Int, cols : Int) : DenseMatrix[Double] = {
+    val m = DenseMatrix.zeros[Double](rows, cols)
+    for(r <- 0 until m.rows; c <- 0 until m.cols) {
+      m(r,c) = v(r * cols + c)
+    }
+    m
+  }
+
+  /** Compute the fht on a given double vector.
+   */
+  implicit val dvDouble1FHT : CanFHT[DenseVector[Double], DenseVector[Double]] = {
+    new CanFHT[DenseVector[Double], DenseVector[Double]] {
+      def apply(v: DenseVector[Double]) = {
+        def _fht(v : DenseVector[Double]) : DenseVector[Double] = {
+            if (v.length > 1) {
+                val p = v.toArray.grouped(2).toList
+                v.slice(0, v.length / 2) := _fht(new DenseVector(p.map(e => (e(0) + e(1)) * nFactor).toArray))
+                v.slice(v.length / 2, v.length) := new DenseVector(p.map(e => (e(0) - e(1)) * nFactor).toArray)
+            }
+            v
+        }
+        _fht(padOrCopy(v))
+      }
+    }
+  }
+
+  /** Compute the fht on a given double matrix.
+    */
+  implicit val dmDouble1FHT : CanFHT[DenseMatrix[Double], DenseMatrix[Double]] = {
+    new CanFHT[DenseMatrix[Double], DenseMatrix[Double]] {
+      def apply(m: DenseMatrix[Double]) = {
+        def _fht(m : DenseMatrix[Double], limit : Int) : Unit = if (limit > 1) {
+            for (c <- 0 until limit) {
+              val p = m(::,c).slice(0,limit).toArray.grouped(2).toList
+              val v = (p.map(e => (e(0) + e(1)) * nFactor) ++ p.map(e => (e(0) - e(1)) * nFactor)).toArray
+              for (r <- 0 until limit) m(r,c) = v(r)
+            }
+            for (r <- 0 until limit) {
+              val p = m(r,::).t.apply(::,0).slice(0,limit).toArray.grouped(2).toList
+              val v = (p.map(e => (e(0) + e(1)) * nFactor) ++ p.map(e => (e(0) - e(1)) * nFactor)).toArray
+              for (c <- 0 until limit) m(r,c) = v(c)
+	    }
+	    _fht(m, limit / 2)
+        }
+
+        val v = squareMatrix(m)
+	_fht(v, v.rows)
+	v
+      }
+    }
+  }
+
+}

--- a/src/main/scala/breeze/signal/support/CanIFHT.scala
+++ b/src/main/scala/breeze/signal/support/CanIFHT.scala
@@ -1,0 +1,74 @@
+package breeze.signal.support
+
+import breeze.linalg.{DenseVector, DenseMatrix}
+
+/**
+ * Construction delegate for getting the IFHT of a value of type InputType.
+ * Implementation details (especially
+ * option arguments) may be added in the future, so it is recommended not
+ * to call this implicit delegate directly.
+ *
+ * @author ktakagaki
+ */
+trait CanIFHT[InputType, OutputType] {
+  def apply(v1: InputType): OutputType
+}
+
+/**
+ * Construction delegate for getting the inverse FHT of a value of type InputType.
+ */
+object CanIFHT {
+
+  private val nFactor = 1d / Math.sqrt(2d)
+
+  /** Compute the fht on a given double vector.
+   */
+  implicit val dvDouble1IFHT : CanIFHT[DenseVector[Double], DenseVector[Double]] = {
+    new CanIFHT[DenseVector[Double], DenseVector[Double]] {
+      def apply(v: DenseVector[Double]) = {
+        def _ifht(v : DenseVector[Double]) : DenseVector[Double] = {
+            if (v.length > 1) {
+                // we will inverse the upper left first
+		val hs = v.length / 2
+		v.slice(0, hs) := _ifht(v.slice(0, hs))
+		val x = v.slice(0,hs).toArray.zip(v.slice(hs,v.length).toArray)
+                DenseVector(x.map(e => List((e._1 + e._2) * nFactor,(e._1 - e._2) * nFactor)).flatten.toArray)
+            } else {
+	       v
+	    }
+        }
+        _ifht(v.copy)
+      }
+    }
+  }
+
+  /** Compute the fht on a given double matrix.
+    */
+  implicit val dmDouble2IFHT : CanIFHT[DenseMatrix[Double], DenseMatrix[Double]] = {
+    new CanIFHT[DenseMatrix[Double], DenseMatrix[Double]] {
+      def apply(m: DenseMatrix[Double]) = {
+        def _ifht(m: DenseMatrix[Double], limit : Int) : Unit = if (limit > 1) {
+          // inverse the upper left first
+          val hs = limit / 2
+          _ifht(m, hs)
+          for (r <- 0 until limit) {
+            val rv =  m(r,::).t.apply(::,0).slice(0,limit).toArray
+            val x = rv.slice(0,hs).zip(rv.slice(hs,limit)).toList
+            val v = x.map(e => List((e._1 + e._2) * nFactor,(e._1 - e._2) * nFactor)).flatten.toArray
+            for (c <- 0 until limit) m(r,c) = v(c)
+          }
+          for (c <- 0 until limit) {
+            val cv = m(::,c).slice(0,limit).toArray
+            val x = cv.slice(0,hs).zip(cv.slice(hs,limit)).toList
+            val v = x.map(e => List((e._1 + e._2) * nFactor,(e._1 - e._2) * nFactor)).flatten.toArray
+            for (r <- 0 until limit) m(r,c) = v(r)
+          }
+	}
+        val r = m.copy
+	_ifht(r, Math.max(r.cols, r.rows))
+        r
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This patch adds a fast haar transformation in 1 and 2d.
The 1d version works on a DenseVector, returning a power-of-two
sized vector that contains the fht.
The 2d version works by applying the fht first column wise and
then row wise.

I've tested it in the sbt console, it works (at least for the cases I've tested). 2d (matrix) fht might need s.o. who uses that method for a deeper review / check.

I hope I got the Can{I,}FHT system right....

Two TODOs are noted: I'm not sure about complex numbers and haar trasforms and I'm not sure if an unscaled int/long version would make sense. It would be easy to add both, but I couldn't find out if these are common / usefull.
