### PR TITLE
convolve/correlate first versions done

### DIFF
--- a/src/main/scala/breeze/signal/filter/FilterKernel.scala
+++ b/src/main/scala/breeze/signal/filter/FilterKernel.scala
@@ -42,15 +42,15 @@ object KernelDesign{
                   The frequencies must lie between (0, nyquist).
                   0 and nyquist should not be included in this array.
 
-    @param optWindow Currently supports a hamming window [[breeze.signal.OptWindowFunction.OptHamming]],
-                  a specified window [[breeze.signal.OptWindowFunction.OptDenseVector]], or
-                  no window [[breeze.signal.OptWindowFunction.OptNone]].
+    @param optWindow Currently supports a hamming window [[breeze.signal.OptWindowFunction.Hamming]],
+                  a specified window [[breeze.signal.OptWindowFunction.User]], or
+                  no window [[breeze.signal.OptWindowFunction.None]].
     @param zeroPass If true (default), the gain at frequency 0 (ie the "DC gain") is 1, if false, 0.
     @param scale Whether to scale the coefficiency so that frequency response is unity at either (A) 0 if zeroPass is true
                  or (B) at nyquist if the first passband ends at nyquist, or (C) the center of the first passband. Default is true.
     @param nyquist The nyquist frequency, default is 1.
     */
-  def firwin(numtaps: Int, cutoff: DenseVector[Double], optWindow: OptWindowFunction = OptWindowFunction.OptHamming(),
+  def firwin(numtaps: Int, cutoff: DenseVector[Double], optWindow: OptWindowFunction = OptWindowFunction.Hamming(),
               zeroPass: Boolean = true, nyquist: Double = 1d, scale: Boolean = true): FIRKernel1D = {
 
     //various variable conditions which must be met
@@ -85,9 +85,9 @@ object KernelDesign{
     }
 
     val win = optWindow match {
-      case OptWindowFunction.OptHamming(alpha, beta) => WindowFunctions.hammingWindow( numtaps, alpha, beta )
-      case OptWindowFunction.OptNone() => DenseVector.ones[Double]( numtaps )
-      case OptWindowFunction.OptDenseVector(dv) => {
+      case OptWindowFunction.Hamming(alpha, beta) => WindowFunctions.hammingWindow( numtaps, alpha, beta )
+      case OptWindowFunction.None() => DenseVector.ones[Double]( numtaps )
+      case OptWindowFunction.User(dv) => {
         require(dv.length == numtaps, "Length of specified window function is not the same as numtaps!")
         dv
       }

--- a/src/main/scala/breeze/signal/options.scala
+++ b/src/main/scala/breeze/signal/options.scala
@@ -16,18 +16,19 @@ abstract class Opt
 
 
 /**Generic option for none.*/
-case class OptNone() extends Opt
-object OptNone {
-  //these implicit conversions will allow breeze.signal.OptNone() object to be given for different functions.
-  implicit def optNoneSpecialize_WindowFunction(x: OptNone) = OptWindowFunction.OptNone()
-  //implicit def optNoneSpecialize_Padding(x: breeze.signal.OptNone) = breeze.signal.OptPadding.OptNone()
+case class None() extends Opt
+object None {
+  //these implicit conversions will allow breeze.signal.None() object to be given for different functions.
+  implicit def optNoneSpecialize_WindowFunction(x: None) = OptWindowFunction.None()
+  implicit def optNoneSpecialize_ConvolveOverhang(x: None) = OptOverhang.None()
+  //implicit def optNoneSpecialize_Padding(x: breeze.signal.None) = breeze.signal.OptPadding.None()
 }
 
 /**Generic option for automatic.*/
-case class OptAutomatic() extends Opt
-object OptAutomatic {
-  //these implicit conversions will allow breeze.signal.OptNone() object to be given for different functions.
-  implicit def optNoneSpecialize_ConvolveMethod(x: OptAutomatic) = OptConvolveMethod.OptAutomatic()
+case class Automatic() extends Opt
+object Automatic {
+  //these implicit conversions will allow breeze.signal.None() object to be given for different functions.
+  implicit def optNoneSpecialize_ConvolveMethod(x: Automatic) = OptMethod.Automatic()
 }
 
 
@@ -36,21 +37,21 @@ object OptAutomatic {
 /**Option values: window function for filter design.*/
 abstract class OptWindowFunction extends Opt
 object OptWindowFunction {
-  case class OptHamming(alpha: Double = 0.54, beta: Double = 0.46) extends OptWindowFunction {
+  case class Hamming(alpha: Double = 0.54, beta: Double = 0.46) extends OptWindowFunction {
     override def toString = "Hamming window ("+ alpha + ", " + beta + ")"
   }
-  case class OptDenseVector(dv: DenseVector[Double]) extends OptWindowFunction {
+  case class User(dv: DenseVector[Double]) extends OptWindowFunction {
     override def toString = "user-specified window"
   }
-  case class OptNone() extends OptWindowFunction{
+  case class None() extends OptWindowFunction{
     override def toString = "no window"
   }
 }
 
 
 /**Option values: how to deal with convolution overhangs.*/
-abstract class OptConvolveOverhang extends Opt
-object OptConvolveOverhang{
+abstract class OptOverhang extends Opt
+object OptOverhang{
   /**Option value: Forms the cyclic convolution whose first element contains data(0)*kernel(k0),
     * and the last element contains data(-1)*kernel(k1).
     *
@@ -60,35 +61,39 @@ object OptConvolveOverhang{
     * {1, 1}: maximal overhang at left hand end
     * {1, -1}: maximal overhangs at both ends.
     */
-  case class OptSequence(k0: Int, k1: Int) extends OptConvolveOverhang
-  /**Option value: Forms the cyclic convolution where the kth kernel element is aligned with each data element.*/
-  case class OptInteger(k: Int) extends OptConvolveOverhang
+  case class Sequence(k0: Int, k1: Int) extends OptOverhang
+  /**Option value: Default, no overhangs, equivalent to Sequence(-1, 1).*/
+  case class None() extends OptOverhang
+  /**Option value: maximal overhangs, equivalent to MatLab conv default ('full'), equivalent to Sequence(1, -1).*/
+  case class Full() extends OptOverhang
+//  /**Option value: Forms the cyclic convolution where the kth kernel element is aligned with each data element.*/
+//  case class OptInteger(k: Int) extends OptOverhang
 }
 
 /**Option values: how to deal with convolution and filter padding.*/
-abstract class OptPadding
+abstract class OptPadding extends Opt
 object OptPadding{
   /**Option value: Performs cyclical convolutions (ie no padding)*/
-  case class OptCyclical() extends OptPadding
+  case class Cyclical() extends OptPadding
   /**Option value: Pads with the first and last components of the data*/
-  case class OptBoundary() extends OptPadding
+  case class Boundary() extends OptPadding
   /**Option value: Pads with a specific value, eg 0.*/
-  case class OptValue[T](value: T) extends OptPadding
+  case class Value[T](value: T) extends OptPadding
 }
 
 /**Option values: how to deal with convolution and filter padding.*/
-abstract class OptConvolveMethod
-object OptConvolveMethod{
+abstract class OptMethod extends Opt
+object OptMethod{
   /**Option value: Decides on the fastest convolve method based on data size and type.*/
-  case class OptAutomatic() extends OptConvolveMethod
+  case class Automatic() extends OptMethod
   /**Option value: Convolve using FFT.*/
-  case class OptFFT() extends OptConvolveMethod
+  case class FFT() extends OptMethod
   /**Option value: Convolve using for loop.*/
-  case class OptLoop() extends OptConvolveMethod
+  case class Loop() extends OptMethod
 }
 
-abstract class OptKernelType
+abstract class OptKernelType extends Opt
 object OptKernelType{
   /**Option value: use firwin() to design FIR kernel using window method.*/
-  case class OptFirwin() extends OptKernelType
+  case class Firwin() extends OptKernelType
 }

--- a/src/main/scala/breeze/signal/package.scala
+++ b/src/main/scala/breeze/signal/package.scala
@@ -32,35 +32,47 @@ package object signal {
   val ifft:inverseFourierTransform.type = inverseFourierTransform
 
   // <editor-fold desc="convolve, correlate">
-  /**Convolves to DenseVectors or DenseMatrixes.</p>
+  /**Convolves DenseVectors.</p>
     * Implementation is via the implicit trait CanConvolve[ InputType,  OutputType ],
     * which is found in breeze.signal.support.CanConvolve.scala.
     *
     * @param kernel DenseVector or DenseMatrix kernel
     * @param data DenseVector or DenseMatrix to be convolved
     * @param canConvolve implicit delegate which is used for implementation. End-users should not use this argument.
-    * @return
     */
-  def convolve[Input, Output](kernel: Input, data: Input,
-                              cyclical: Boolean = true,
-                              optOverhang: OptConvolveOverhang = OptConvolveOverhang.OptSequence(-1, 1),
-                              optConvolveMethod: OptConvolveMethod = OptAutomatic()
+  def convolve[Input, Output](data: Input, kernel: Input,
+                              overhang: OptOverhang = OptOverhang.None(),
+                              padding: OptPadding = OptPadding.Value(0d),
+                              method: OptMethod = Automatic()
                               )
                              (implicit canConvolve: CanConvolve[Input, Output]): Output =
-    canConvolve(kernel, data, cyclical, optOverhang, optConvolveMethod)
+    canConvolve(data, kernel, correlate=false, overhang, padding, method)
+
+  /**Correlates DenseVectors.</p>
+    * Implementation is via the implicit trait CanConvolve[ InputType,  OutputType ],
+    * which is found in breeze.signal.support.CanConvolve.scala.
+    * See [[breeze.signal.convolve]] for options and other information.
+    */
+  def correlate[Input, Output](data: Input, kernel: Input,
+                              overhang: OptOverhang = OptOverhang.None(),
+                              padding: OptPadding = OptPadding.Value(0d),
+                              method: OptMethod = Automatic()
+                               )
+                             (implicit canConvolve: CanConvolve[Input, Output]): Output =
+    canConvolve(data, kernel, correlate=true, overhang, padding, method)
 
   // </editor-fold>
 
 //  def filter[Input, Kernel, Output](data: Input, kernel: Kernel,
-//                             optPadding: OptPadding = OptPadding.OptBoundary)
+//                             padding: OptPadding = OptPadding.Boundary)
 //        (implicit canFilter: CanFilter[Input, Kernel, Output]): Output =
-//    canFilter(data, kernel, optPadding)
+//    canFilter(data, kernel, padding)
 //
 //  def filterBandpass[Input, Output](data: Input, omega: (Double, Double),
 //                             sampleRate: Double = 1d,
 //                             optKernelType: OptKernelType = OptKernelType.optFirwin,
-//                             optPadding: OptPadding = OptPadding.OptBoundary)
+//                             padding: OptPadding = OptPadding.Boundary)
 //        (implicit canFilterBPBS: CanFilterBPBS[Input, FIRKernel1D, Output]): Output =
-//    canFilterBPBS(data, omega, sampleRate, optKernelType, optPadding, bandStop = false)
+//    canFilterBPBS(data, omega, sampleRate, optKernelType, padding, bandStop = false)
 
 }

--- a/src/main/scala/breeze/signal/support/CanConvlolve.scala
+++ b/src/main/scala/breeze/signal/support/CanConvlolve.scala
@@ -3,10 +3,10 @@ package breeze.signal.support
 /**
  * @author ktakagaki
  */
-import breeze.linalg.{DenseVector, DenseMatrix}
-import breeze.signal._
+import breeze.generic.UFunc
 import breeze.macros.expand
-
+import breeze.linalg.{reverse, DenseVector, DenseMatrix}
+import breeze.signal._
 
 //ToDo 1: provide convolve of Integer and other DenseVectors
 //ToDo 1: provide convolve of DenseMatrix
@@ -21,7 +21,11 @@ import breeze.macros.expand
  * @author ktakagaki
  */
 trait CanConvolve[InputType, OutputType] {
-  def apply(data: InputType, kernel: InputType, cyclical: Boolean, optOverhang: OptConvolveOverhang, optConvolveMethod: OptConvolveMethod): OutputType
+  def apply(data: InputType, kernel: InputType,
+            correlate: Boolean,
+            overhang: OptOverhang,
+            padding: OptPadding,
+            method: OptMethod): OutputType
 }
 
 /**
@@ -40,59 +44,83 @@ object CanConvolve {
   implicit val dvDouble1DConvolve : CanConvolve[DenseVector[Double], DenseVector[Double]] = {
     new CanConvolve[DenseVector[Double], DenseVector[Double]] {
       def apply(data: DenseVector[Double], kernel: DenseVector[Double],
-                cyclical: Boolean,
-                optOverhang: OptConvolveOverhang,
-                optConvolveMethod: OptConvolveMethod): DenseVector[Double] = {
+                correlate: Boolean,
+                overhang: OptOverhang,
+                padding: OptPadding,
+                method: OptMethod): DenseVector[Double] = {
 
-//        optOverhang match  {
-//          case x: OptConvolveOverhang.OptDefault => {
-//            require(kernel.length <= data.length, "kernel length must be shorter or equal to data")
-//            //for(cRes <- 0 until (data.length - kernel.length +1) ) yield sum(kernel :* data(cRes until cRes + kernel.length))
-//            val tempRet = new Array[Double](data.length - kernel.length +1)
-//            var cKern = 0
-//            var cRes = 0
-//            while(cRes < tempRet.length ){
-//              while(cKern < kernel.length){
-//                tempRet(cRes) += kernel(kernel.length - cKern -1) * data(cRes + cKern)
-//                cKern += 1
-//              }
-//              cRes += 1
-//              cKern = 0
-//            }
-//            DenseVector[Double](tempRet)
-//          }
-//            //What should be returned here for invalid parameters? Throw error?
-//          case f => println("The overhang option " + f + " is not supported!"); DenseVector[Double]()
-//        }
+        val optConvolveOverhangParsed = overhang match {
+          case OptOverhang.None() => OptOverhang.Sequence(-1, 1)
+          case OptOverhang.Full() => OptOverhang.Sequence(1, -1)
+          case o => o
+        }
 
-        DenseVector[Double]()
+        val kl = kernel.length
+        val dl = data.length
+        val paddedData = optConvolveOverhangParsed match {
+          case OptOverhang.Sequence(-1, 1) => data
+          case OptOverhang.Sequence(1, -1) =>
+            DenseVector.vertcat(
+              padding match {
+                case OptPadding.Cyclical() => data( dl - (kl-1) to dl - 1 )
+                case OptPadding.Boundary() => DenseVector.ones[Double](kernel.length-1) * data( 0 )
+                case OptPadding.Value(v: Double) => DenseVector.ones[Double](kernel.length-1) * v
+                case op => require(false, "cannot handle OptPadding value " + op); DenseVector[Double]()
+              },
+              data,
+              padding match {
+                case OptPadding.Cyclical() => data( 0 to kl-1 )
+                case OptPadding.Boundary() => DenseVector.ones[Double](kernel.length-1) * data( dl - 1  )
+                case OptPadding.Value(v: Double) => DenseVector.ones[Double](kernel.length-1) * v
+                case op => require(false, "cannot handle OptPadding value " + op); DenseVector[Double]()
+              }
+            )
+          case oc => require(false, "cannot handle OptOverhang value " + oc); data
+        }
+
+        if(correlate) correlateLoopNoOverhang( paddedData, kernel )
+        else convolveLoopNoOverhang( paddedData, kernel )
       }
     }
   }
 
 
+}
+
+object convolveLoopNoOverhang extends UFunc{
+
   @expand
-  def convolveLoopNoOverhang[@expand.args(Int, Double, Float, Long) T](data: DenseVector[T], kernel: DenseVector[T]): DenseVector[T] =
-    correlateLoopNoOverhang(data, reverse(kernel))
-  @expand
-  def correlateLoopNoOverhang[@expand.args(Int, Double, Float, Long) T](data: DenseVector[T], kernel: DenseVector[T]): DenseVector[T] = {
-    require( data.length * kernel.length != 0, "data and kernel must be non-empty DenseVectors")
-    require( data.length >= kernel.length, "kernel cannot be longer than data to be convolved/coorelated!")
-
-    DenseVector.tabulate(data.length - kernel.length + 1)(
-      di => {
-        var ki: T = 0
-        var sum: T = 0
-        while(c < kernel.length){
-          s += data(di + ki)*kernel(ki)
-          c += 1
-        }
-        s
-      }
-    )
-
-  }
-
+  @expand.valify
+  implicit def convolveLoopNoOverhang[@expand.args(Int, Double, Float, Long) T]: Impl2[DenseVector[T], DenseVector[T], DenseVector[T]] =
+    new Impl2[DenseVector[T], DenseVector[T], DenseVector[T]] {
+      def apply(data: DenseVector[T], kernel: DenseVector[T]) = correlateLoopNoOverhang(data, reverse(kernel))
+    }
 
 }
 
+object correlateLoopNoOverhang extends UFunc{
+
+  @expand
+  @expand.valify
+  implicit def convolveLoopNoOverhang[@expand.args(Int, Double, Float, Long) T]: Impl2[DenseVector[T], DenseVector[T], DenseVector[T]] =
+    new Impl2[DenseVector[T], DenseVector[T], DenseVector[T]] {
+      def apply(data: DenseVector[T], kernel: DenseVector[T]) = {
+        require( data.length * kernel.length != 0, "data and kernel must be non-empty DenseVectors")
+        require( data.length >= kernel.length, "kernel cannot be longer than data to be convolved/coorelated!")
+
+        DenseVector.tabulate(data.length - kernel.length + 1)(
+          di => {
+            var ki: Int = 0
+            var sum: T = 0
+            while(ki < kernel.length){
+              sum += data( (di + ki) ) * kernel(ki)
+              ki += 1
+            }
+            sum
+          }
+        )
+
+      }
+    }
+
+}

--- a/src/main/scala/breeze/signal/support/CanFilter.scala
+++ b/src/main/scala/breeze/signal/support/CanFilter.scala
@@ -18,8 +18,8 @@
 // */
 //trait CanFilter[InputType, Kernel, OutputType] {
 //  def apply(data: InputType, kernel: Kernel,
-//            optConvolveOverhang: OptConvolveOverhang,
-//            optPadding: OptPadding = OptPadding.OptBoundary ): OutputType
+//            overhang: OptOverhang,
+//            padding: OptPadding = OptPadding.Boundary ): OutputType
 //}
 //
 ///**
@@ -37,13 +37,13 @@
 //    */
 //  implicit val dvDouble1DFilter : CanFilter[DenseVector[Double], FIRKernel1D, DenseVector[Double]] = {
 //    new CanFilter[DenseVector[Double], FIRKernel1D, DenseVector[Double]] {
-//      def apply(data: DenseVector[Double], kernel: FIRKernel1D, optConvolveOverhang1: OptConvolveOverhang, optPadding: OptPadding) = {
+//      def apply(data: DenseVector[Double], kernel: FIRKernel1D, optConvolveOverhang1: OptOverhang, padding: OptPadding) = {
 //
-////        optPadding match  {
-////          case x: OptPadding.OptNone => {}
+////        padding match  {
+////          case x: OptPadding.None => {}
 ////        }
 ////
-////        convolve(data, kernel, cyclical = false, optOverhang = optConvolveOverhang1, optConvolveMethod: OptConvolveMethod)
+////        convolve(data, kernel, cyclical = false, overhang = optConvolveOverhang1, method: OptMethod)
 //        DenseVector[Double]()
 //
 //      }
@@ -56,7 +56,7 @@
 ////abstract class OptSampleRate
 ////object OptSampleRate{
 ////  case class OptConvolveDefault() extends OptSampleRate
-////  case class OptValue(sampleRate: Double) extends OptSampleRate
+////  case class Value(sampleRate: Double) extends OptSampleRate
 ////}
 //
 //

--- a/src/main/scala/breeze/signal/support/CanFilterXX.scala
+++ b/src/main/scala/breeze/signal/support/CanFilterXX.scala
@@ -20,8 +20,8 @@
 //  def apply(data: DenseVector[Double], omega: (Double, Double),
 //            sampleRate: Double, numtaps: Int, bandStop: Boolean,
 //            optKernelType: OptKernelType,
-//            optConvolveOverhang: OptConvolveOverhang,
-//            optPadding: OptPadding = OptPadding.OptBoundary): OutputType
+//            overhang: OptOverhang,
+//            padding: OptPadding = OptPadding.Boundary): OutputType
 //}
 //
 ///**
@@ -41,18 +41,18 @@
 //    new CanFilterBPBS[DenseVector[Double], DenseVector[Double]] {
 //      def apply(data: DenseVector[Double], omega: (Double, Double),
 //                sampleRate: Double = 1d, numtaps: Int = 512, bandStop: Boolean = false,
-//                optKernelType: OptKernelType = OptKernelType.OptFirwin,
-//                optConvolveOverhang: OptConvolveOverhang,
-//                optPadding: OptPadding = OptPadding.OptBoundary): DenseVector[Double] = {
+//                optKernelType: OptKernelType = OptKernelType.Firwin,
+//                overhang: OptOverhang,
+//                padding: OptPadding = OptPadding.Boundary): DenseVector[Double] = {
 //
 //        val kernel = optKernelType match  {
 //          case x: OptKernelType.OptDefault => KernelDesign.firwin( numtaps, DenseVector[Double](omega._1, omega._2), zeroPass = bandStop, nyquist = sampleRate/2d)
-//          case x: OptKernelType.OptFirwin =>  KernelDesign.firwin( numtaps, DenseVector[Double](omega._1, omega._2), zeroPass = bandStop, nyquist = sampleRate/2d)
+//          case x: OptKernelType.Firwin =>  KernelDesign.firwin( numtaps, DenseVector[Double](omega._1, omega._2), zeroPass = bandStop, nyquist = sampleRate/2d)
 //          case x => require(false, "Cannot handle option value "+ x)
 //        }
 //
-////        val optConvolveOverhang1 = optConvolveOverhang
-////        filter(data, kernel, optConvolveOverhang = optConvolveOverhang1, optPadding = OptPadding.OptBoundary)
+////        val optConvolveOverhang1 = overhang
+////        filter(data, kernel, overhang = optConvolveOverhang1, padding = OptPadding.Boundary)
 //        DenseVector[Double]()
 //      }
 //    }

--- a/src/test/scala/breeze/signal/SignalTest.scala
+++ b/src/test/scala/breeze/signal/SignalTest.scala
@@ -129,13 +129,17 @@ class SignalTest extends FunSuite {
   ).t.reshape(5,5).t
   // </editor-fold>
 
-  // <editor-fold desc="convolve">
-  test("convolve of DenseVector[Double]") {
+  // <editor-fold desc="convolve/correlate">
+  test("convolve/correlate") {
     val kernel = DenseVector(1.0, 2.0)
     val data = DenseVector(2.0, 3.0, 4.0, 5.0)
-    assert( convolve(kernel, data) == DenseVector(7.0, 10.0, 13.0) )
+    assert( convolve(data, kernel) == DenseVector(7.0, 10.0, 13.0) )
+    assert( correlate(data, kernel) == DenseVector(8.0, 11.0, 14.0) )
+    assert( convolve(data, kernel, overhang = OptOverhang.Full() ) == DenseVector(2.0, 7.0, 10.0, 13.0, 10) )
+    assert( correlate(data, kernel, overhang = OptOverhang.Full() ) == DenseVector(4.0, 8.0, 11.0, 14.0, 5.0) )
   }
-  //ListConvolve[{1, 2}, {2, 3, 4, 5}]
+  //MatLab: conv(2 : 5, 1 : 2)
+  //Mathematica: ListConvolve[{1, 2}, {2, 3, 4, 5}]
 
   // </editor-fold>
 }

--- a/src/test/scala/breeze/signal/filter/FilterDesignTest.scala
+++ b/src/test/scala/breeze/signal/filter/FilterDesignTest.scala
@@ -12,13 +12,13 @@ class FilterDesignTest extends FunSuite {
 
   test("firwin tested against output from scipy.signal.firwin (0.13.2-1)") {
     val testNormThreshold = 1.0E-10
-    val firwin1 = KernelDesign.firwin(6, DenseVector(0.5), OptWindowFunction.OptHamming(),
+    val firwin1 = KernelDesign.firwin(6, DenseVector(0.5), OptWindowFunction.Hamming(),
                     zeroPass = true, nyquist = 1d, scale = true)
     assert( norm( testFirwin1 - firwin1.kernel) < testNormThreshold )
-    val firwin2 = KernelDesign.firwin(3, DenseVector(10.0), OptWindowFunction.OptHamming(),
+    val firwin2 = KernelDesign.firwin(3, DenseVector(10.0), OptWindowFunction.Hamming(),
       zeroPass = true, nyquist = 15.0, scale = false)
     assert( norm( testFirwin2 - firwin2.kernel) < testNormThreshold )
-    val firwin3 = KernelDesign.firwin(5, DenseVector(6.0, 10.0), OptWindowFunction.OptHamming(),
+    val firwin3 = KernelDesign.firwin(5, DenseVector(6.0, 10.0), OptWindowFunction.Hamming(),
       zeroPass = false, nyquist = 15.0, scale = false)
     assert( norm( testFirwin3 - firwin3.kernel) < testNormThreshold )
   }


### PR DESCRIPTION
Hi David,

I've finished my first pass at convolve/correlate. I'm interested to hear what you think of the syntax, especially for option passing with case classes. The options are all placed in breeze.signal/options.scala

These are some examples of how one would use convolve/correlate, as I have it now...

```
val kernel = DenseVector(1.0, 2.0)
val data = DenseVector(2.0, 3.0, 4.0, 5.0)

//default has no overhangs
convolve(data, kernel)  =>  DenseVector(7.0, 10.0, 13.0)

//this is the MatLab default, with zero padding on both ends (i.e. padding = OptPadding.Value(0d) )
convolve(data, kernel, overhang = OptOverhang.Full() ) => DenseVector(2.0, 7.0, 10.0, 13.0, 10)

//one can also specify padding with the boundary values (first and last element of the data)
//which is sometimes done in DSP, especially image processing....   padding = OptPadding.Boundary()

//one can also specify cyclical padding, which is also common in DSP...
//padding = OptPadding.Cyclical()
```

I'll edit if you have any comments, and then I plan to document it all with scaladoc and in the Wiki.
At some point, I'd like to put in fft convolution for longish floating-point DV's

```
convolve(  data,  kernel,  ...,  method = OptMethod.FFT()  )
```

Kenta
