### PR TITLE
toVector

### DIFF
--- a/src/main/scala/breeze/linalg/DenseVector.scala
+++ b/src/main/scala/breeze/linalg/DenseVector.scala
@@ -166,7 +166,7 @@ class DenseVector[@spec(Double, Int, Float) E](val data: Array[E],
 
 
   /**
-   * Slices the DenseVector, in the range (start,end] with a stride stride.
+   * Slices the DenseVector, in the range [start,end] with a stride stride.
    * @param start
    * @param end
    * @param stride
@@ -190,6 +190,8 @@ class DenseVector[@spec(Double, Int, Float) E](val data: Array[E],
     }
     arr
   }
+
+
 }
 
 

--- a/src/main/scala/breeze/linalg/Vector.scala
+++ b/src/main/scala/breeze/linalg/Vector.scala
@@ -74,6 +74,7 @@ trait Vector[@spec(Int, Double, Float) E] extends VectorLike[E, Vector[E]]{
     new DenseVector(toArray)
   }
 
+  /**Returns copy of this [[breeze.linalg.Vector]] as a [[scala.Array]]*/
   def toArray(implicit cm: ClassTag[E]) = {
     val result = new Array[E](length)
     var i = 0
@@ -83,6 +84,9 @@ trait Vector[@spec(Int, Double, Float) E] extends VectorLike[E, Vector[E]]{
     }
     result
   }
+
+  /**Returns copy of this [[breeze.linalg.Vector]] as a [[scala.Vector]]*/
+  def toVector(implicit cm: ClassTag[E]) = Vector[E]( toArray )
 
 }
 


### PR DESCRIPTION
1. Is it OK if I put in DenseVector.toVector() in addition to toArray()?
2. Can you check the comments for DenseVector.scala Line 169 below, I think it might have been ?wrong
3. What is the reason that DenseVector[] doesn't support Long? For the Signal Processing, some faster integer algorithms could use it, to lessen the risk that Int overflows... not critical, but just wondering for my information.
