### PR TITLE
Created unsafeUpdate, unsafeValueAt for DenseVector. 

### DIFF
--- a/src/main/scala/breeze/linalg/DenseVector.scala
+++ b/src/main/scala/breeze/linalg/DenseVector.scala
@@ -69,11 +69,13 @@ class DenseVector[@spec(Double, Int, Float) E](val data: Array[E],
     data(offset + trueI * stride)
   }
 
-  def update(i: Int, v: E) {
+  def update(i: Int, v: E) = {
     if(i < - size || i >= size) throw new IndexOutOfBoundsException(i + " not in [-"+size+","+size+")")
     val trueI = if(i<0) i+size else i
     data(offset + trueI * stride) = v
   }
+
+  def unsafeUpdate(i: Int, v: E) = { data(offset + i * stride) = v }
 
   def activeIterator = iterator
 
@@ -117,6 +119,11 @@ class DenseVector[@spec(Double, Int, Float) E](val data: Array[E],
    * @return apply(i)
    */
   def valueAt(i: Int): E = apply(i)
+
+  /**
+    * Unsafe version of above, a way to skip the checks.
+    */
+  def unsafeValueAt(i: Int): E = data(offset + i * stride)
 
   /**
    * Gives the logical index from the physical index.
@@ -216,13 +223,14 @@ object DenseVector extends VectorConstructors[DenseVector] with DenseVector_Gene
 
 
   def apply[@spec(Double, Float, Int) V](values: Array[V]) = new DenseVector(values)
-  def ones[@spec(Double, Float, Int) V: ClassTag:Semiring](size: Int) = {
+  def ones[@spec(Double, Float, Int) V: ClassTag:Semiring](size: Int) = fill[V](size, implicitly[Semiring[V]].one)
+
+  def fill[@spec(Double, Float, Int) V: ClassTag:Semiring](size: Int, v: V) = {
     val r = apply(new Array[V](size))
     assert(r.stride == 1)
-    ArrayUtil.fill(r.data, r.offset, r.length, implicitly[Semiring[V]].one)
+    ArrayUtil.fill(r.data, r.offset, r.length, v)
     r
   }
-
 
     // concatenation
   /**
@@ -425,14 +433,14 @@ object DenseVector extends VectorConstructors[DenseVector] with DenseVector_Gene
       }
     }
   }
-  
+
   implicit def canTransposeComplex: CanTranspose[DenseVector[Complex], DenseMatrix[Complex]] = {
     new CanTranspose[DenseVector[Complex], DenseMatrix[Complex]] {
       def apply(from: DenseVector[Complex]) = {
-        new DenseMatrix(data = from.data map { _.conjugate }, 
-                        offset = from.offset, 
-                        cols = from.length, 
-                        rows = 1, 
+        new DenseMatrix(data = from.data map { _.conjugate },
+                        offset = from.offset,
+                        cols = from.length,
+                        rows = 1,
                         majorStride = from.stride)
       }
     }
@@ -622,4 +630,3 @@ object DenseVector extends VectorConstructors[DenseVector] with DenseVector_Gene
   @noinline
   private def init() = {}
 }
-


### PR DESCRIPTION
These can significantly improve performance, though of course at the cost of safety. 

In terms of performance, consider the following implementation of Horner's algorithm for applying a polynomial to a dense vector (part of my incomplete polynomial branch): 

```
  def apply(k: PolyDenseUFuncWrapper, v: DenseVector[Double]) = {
    val coeffs: Array[Double] = k.p.coeffs
    var i = coeffs.length - 1
    var result = DenseVector.fill[Double](v.size, coeffs(i))
    while (i > 0) {
      i -= 1
      val c = coeffs(i)
      cfor(0)(j => j < result.size, j => j+1)( j => {
        result.unsafeUpdate(j, result.unsafeValueAt(j)*v.unsafeValueAt(j)+c)
        // result.update(j, result.valueAt(j)*v.valueAt(j)+c)
      })
    }
    result
  }
```

Consider the benchmark which runs the above code:

```
  cfor(0)(j => j < 100, j => j+1)(j => {
    p(x)
  })
```

Here, `x` is a `DenseVector` with size 30 million. The version using `unsafe` functions takes 26-27 seconds to run, the safe version takes 32-35 seconds. That's a speedup worth exploiting, in my opinion. 

Tangentially, building a specialized version of `DenseVector` specialized to the case where `stride=1` can also yield a speedup. 
