### PR TITLE
Correcting DenseVectorBenchmark

### DIFF
--- a/benchmark/src/main/scala/breeze/linalg/DenseVectorBenchmark.scala
+++ b/benchmark/src/main/scala/breeze/linalg/DenseVectorBenchmark.scala
@@ -12,7 +12,7 @@ trait BuildsRandomVectors {
   def randomArray(size: Int, offset: Int = 0, stride: Int = 1): DenseVector[Double] = {
     require(offset >= 0)
     require(stride >= 1)
-    val result = DenseVector(new Array[Double](offset+stride*size)).slice(offset + (stride - 1) * size, offset + stride*size)
+    val result = new DenseVector(new Array[Double](offset+stride*size), offset, stride, size)
     var i=0
     while (i < size) {
       result.unsafeUpdate(i, uniform.draw())


### PR DESCRIPTION
The DenseVectorBenchmark doesn't look like it's correctly using stride in it's tests. I've attempted to fix the issue.
