### PR TITLE
(INCOMPLETE) Replacing Field with Spire's equivalent

### DIFF
--- a/src/main/scala/breeze/linalg/Counter.scala
+++ b/src/main/scala/breeze/linalg/Counter.scala
@@ -16,12 +16,14 @@ package breeze.linalg
 */
 
 import breeze.storage.DefaultArrayValue
-import breeze.math.{TensorSpace, Ring, Semiring, Field}
+import breeze.math.{TensorSpace, Ring, Semiring, TemporaryFieldTranslation}
 import breeze.generic._
 import collection.Set
 import operators._
 import breeze.linalg.support._
 import CanTraverseValues.ValuesVisitor
+import spire.algebra.Field
+import spire.implicits._
 
 /**
  * A map-like tensor that acts like a collection of key-value pairs where
@@ -155,5 +157,3 @@ object Counter extends CounterOps {
     TensorSpace.make[Counter[K, V], K, V]
   }
 }
-
-

--- a/src/main/scala/breeze/linalg/Counter.scala
+++ b/src/main/scala/breeze/linalg/Counter.scala
@@ -153,6 +153,7 @@ object Counter extends CounterOps {
   }
 
   implicit def tensorspace[K, V](implicit field: Field[V], dfv: DefaultArrayValue[V], normImpl: norm.Impl[V, Double]) = {
+    implicit val ring = new TemporaryFieldTranslation(field)
     implicit def zipMap = Counter.zipMap[K, V, V]
     TensorSpace.make[Counter[K, V], K, V]
   }

--- a/src/main/scala/breeze/linalg/DenseVector.scala
+++ b/src/main/scala/breeze/linalg/DenseVector.scala
@@ -19,7 +19,7 @@ import scala.{specialized=>spec}
 import breeze.generic._
 import breeze.linalg.support._
 import breeze.linalg.operators._
-import breeze.math.{Complex, TensorSpace, Semiring, Ring}
+import breeze.math.{Complex, TensorSpace, Semiring, Ring, BreezeFields}
 import breeze.util.{ArrayUtil, Isomorphism}
 import breeze.storage.DefaultArrayValue
 import scala.reflect.ClassTag
@@ -27,6 +27,8 @@ import com.github.fommil.netlib.BLAS.{getInstance => blas}
 import breeze.macros.expand
 import scala.math.BigInt
 import CanTraverseValues.ValuesVisitor
+import spire.implicits._
+import BreezeFields._
 
 /**
  * A DenseVector is the "obvious" implementation of a Vector, with one twist.

--- a/src/main/scala/breeze/linalg/HashVector.scala
+++ b/src/main/scala/breeze/linalg/HashVector.scala
@@ -5,7 +5,7 @@ import breeze.linalg.operators._
 import breeze.storage.{ConfigurableDefault, DefaultArrayValue}
 import breeze.generic._
 import breeze.linalg.support._
-import breeze.math.{Semiring, TensorSpace, Ring, Complex}
+import breeze.math.{Semiring, TensorSpace, Ring, Complex, BreezeFields}
 import scala.reflect.ClassTag
 import scala.util.hashing.MurmurHash3
 import breeze.macros.expand
@@ -13,6 +13,8 @@ import scala.math.BigInt
 import CanTraverseValues.ValuesVisitor
 import breeze.generic.UFunc.UImpl2
 import breeze.linalg.support.CanTraverseKeyValuePairs.KeyValuePairsVisitor
+import spire.implicits._
+import BreezeFields._
 
 /**
  * A HashVector is a sparse vector backed by an OpenAddressHashArray
@@ -259,6 +261,3 @@ object HashVector extends HashVectorOps
   @noinline
   private def init() = {}
 }
-
-
-

--- a/src/main/scala/breeze/linalg/MutableInnerProductSpaceDenseMatrix.scala
+++ b/src/main/scala/breeze/linalg/MutableInnerProductSpaceDenseMatrix.scala
@@ -5,6 +5,7 @@ import support._
 import breeze.math.MutableInnerProductSpace
 import breeze.math.Semiring
 import DenseMatrix._
+import spire.implicits._
 
 /** Import this to provide access to a DenseMatrix[Double] as a MutableInnerProductSpace, so it can be used in optimization. */
 object MutableInnerProductSpaceDenseMatrixDouble {

--- a/src/main/scala/breeze/linalg/SparseVector.scala
+++ b/src/main/scala/breeze/linalg/SparseVector.scala
@@ -19,12 +19,15 @@ import scala.{specialized=>spec}
 import breeze.storage.DefaultArrayValue
 import breeze.linalg.support._
 import breeze.util.ArrayUtil
-import breeze.math.{Complex, Ring, TensorSpace}
+import breeze.math.{Complex, Ring, TensorSpace, BreezeFields}
 import breeze.collection.mutable.SparseArray
 import collection.mutable
 import scala.reflect.ClassTag
 import CanTraverseValues.ValuesVisitor
 import breeze.generic.UFunc.UImpl
+import spire.algebra.Field
+import spire.implicits._
+import BreezeFields._
 
 
 /**
@@ -318,7 +321,7 @@ object SparseVector extends SparseVectorOps
     TensorSpace.make[SparseVector[Float], Int, Float]
   }
   implicit val space_i: TensorSpace[SparseVector[Int], Int, Int] = TensorSpace.make[SparseVector[Int], Int, Int]
-  
+
   implicit def canTranspose[V:ClassTag:DefaultArrayValue]: CanTranspose[SparseVector[V], CSCMatrix[V]] = {
     new CanTranspose[SparseVector[V], CSCMatrix[V]] {
       def apply(from: SparseVector[V]) = {
@@ -333,7 +336,7 @@ object SparseVector extends SparseVectorOps
       }
     }
   }
-  
+
   implicit def canTransposeComplex: CanTranspose[SparseVector[Complex], CSCMatrix[Complex]] = {
     new CanTranspose[SparseVector[Complex], CSCMatrix[Complex]] {
       def apply(from: SparseVector[Complex]) = {
@@ -353,5 +356,3 @@ object SparseVector extends SparseVectorOps
   @noinline
   private def init() = {}
 }
-
-

--- a/src/main/scala/breeze/linalg/Vector.scala
+++ b/src/main/scala/breeze/linalg/Vector.scala
@@ -17,7 +17,7 @@ package breeze.linalg
 import operators._
 import scala.{specialized=>spec}
 import breeze.generic.{UFunc}
-import breeze.math.{Complex, TensorSpace, Ring}
+import breeze.math.{Complex, TensorSpace, Ring, BreezeFields}
 import scala.math.BigInt
 import collection.immutable.BitSet
 import breeze.linalg.support._
@@ -29,6 +29,8 @@ import scala.annotation.unchecked.uncheckedVariance
 import CanTraverseValues.ValuesVisitor
 import scala.collection.mutable.ArrayBuilder
 import breeze.generic.UFunc.{UImpl2, UImpl, InPlaceImpl2}
+import spire.implicits._
+import BreezeFields._
 
 /**
  * Trait for operators and such used in vectors.

--- a/src/main/scala/breeze/linalg/VectorBuilder.scala
+++ b/src/main/scala/breeze/linalg/VectorBuilder.scala
@@ -18,11 +18,12 @@ import operators._
 import scala.{specialized=>spec}
 import support._
 import breeze.util.{Sorting, ArrayUtil}
-import breeze.math.{Field, MutableVectorSpace, Semiring, Ring}
+import breeze.math.{MutableVectorSpace, Semiring, Ring}
 import breeze.storage.DefaultArrayValue
 import scala.reflect.ClassTag
 import breeze.macros.expand
 import breeze.generic.UFunc.{UImpl2, InPlaceImpl2}
+import spire.algebra.Field
 
 
 /**
@@ -348,5 +349,3 @@ object VectorBuilder extends VectorBuilderOps {
   }
 
 }
-
-

--- a/src/main/scala/breeze/linalg/operators/BinaryOp.scala
+++ b/src/main/scala/breeze/linalg/operators/BinaryOp.scala
@@ -15,7 +15,7 @@ package breeze.linalg.operators
  limitations under the License.
 */
 import breeze.generic.{UFunc, MMRegistry2, Multimethod2}
-import breeze.math.{Field, Ring, Semiring}
+import breeze.math.{Ring, Semiring}
 import breeze.linalg.support.CanCopy
 import breeze.numerics.IntMath
 import scala.annotation.unchecked.uncheckedVariance

--- a/src/main/scala/breeze/linalg/operators/Counter2Ops.scala
+++ b/src/main/scala/breeze/linalg/operators/Counter2Ops.scala
@@ -2,7 +2,7 @@ package breeze.linalg
 package operators
 
 import breeze.storage.DefaultArrayValue
-import breeze.math.{Ring, Semiring}
+import breeze.math.{Ring, Semiring, TemporaryFieldTranslation}
 import breeze.linalg.support.{CanZipMapValues, CanAxpy, CanCopy}
 import breeze.generic.UFunc.{UImpl2, InPlaceImpl2}
 import spire.algebra.Field
@@ -182,6 +182,7 @@ trait Counter2Ops {
                                    field: Field[V],
                                    d: DefaultArrayValue[V]):OpDiv.Impl2[Counter2[K1, K2, V], Counter2[K1, K2, V], Counter2[K1, K2, V]] = {
     new OpDiv.Impl2[Counter2[K1, K2, V], Counter2[K1, K2, V], Counter2[K1, K2, V]] {
+      private implicit val ring = new TemporaryFieldTranslation(field)
       override def apply(a : Counter2[K1, K2, V], b : Counter2[K1, K2, V]) = {
         val r = Counter2[K1, K2, V]()
         for( (k, v) <- a.activeIterator) {
@@ -198,6 +199,7 @@ trait Counter2Ops {
                                    field: Field[V],
                                    d: DefaultArrayValue[V]):OpDiv.Impl2[Counter2[K1, K2, V], V, Counter2[K1, K2, V]] = {
     new OpDiv.Impl2[Counter2[K1, K2, V], V, Counter2[K1, K2, V]] {
+      private implicit val ring = new TemporaryFieldTranslation(field)
       override def apply(a : Counter2[K1, K2, V], b : V) = {
         val r = Counter2[K1, K2, V]()
         for( (k, v) <- a.activeIterator) {

--- a/src/main/scala/breeze/linalg/operators/Counter2Ops.scala
+++ b/src/main/scala/breeze/linalg/operators/Counter2Ops.scala
@@ -2,9 +2,10 @@ package breeze.linalg
 package operators
 
 import breeze.storage.DefaultArrayValue
-import breeze.math.{Field, Ring, Semiring}
+import breeze.math.{Ring, Semiring}
 import breeze.linalg.support.{CanZipMapValues, CanAxpy, CanCopy}
 import breeze.generic.UFunc.{UImpl2, InPlaceImpl2}
+import spire.algebra.Field
 
 
 
@@ -171,20 +172,20 @@ trait Counter2Ops {
       val field = implicitly[Field[V]]
       def apply(a: Counter2[K1, K2, V], b: Counter2[K1, K2, V]) {
         for( (k,v) <- a.activeIterator) {
-          a(k) = field./(v, b(k))
+          a(k) = field.quot(v, b(k))
         }
       }
     }
   }
 
   implicit def canDivVV[K1, K2, V](implicit copy: CanCopy[Counter2[K1, K2, V]],
-                                   semiring: Field[V],
+                                   field: Field[V],
                                    d: DefaultArrayValue[V]):OpDiv.Impl2[Counter2[K1, K2, V], Counter2[K1, K2, V], Counter2[K1, K2, V]] = {
     new OpDiv.Impl2[Counter2[K1, K2, V], Counter2[K1, K2, V], Counter2[K1, K2, V]] {
       override def apply(a : Counter2[K1, K2, V], b : Counter2[K1, K2, V]) = {
         val r = Counter2[K1, K2, V]()
         for( (k, v) <- a.activeIterator) {
-          val vr = semiring./(v, b(k))
+          val vr = field.quot(v, b(k))
           r(k) = vr
         }
         r
@@ -194,13 +195,13 @@ trait Counter2Ops {
 
 
   implicit def canDivVS[K1, K2, V](implicit copy: CanCopy[Counter2[K1, K2, V]],
-                                   semiring: Field[V],
+                                   field: Field[V],
                                    d: DefaultArrayValue[V]):OpDiv.Impl2[Counter2[K1, K2, V], V, Counter2[K1, K2, V]] = {
     new OpDiv.Impl2[Counter2[K1, K2, V], V, Counter2[K1, K2, V]] {
       override def apply(a : Counter2[K1, K2, V], b : V) = {
         val r = Counter2[K1, K2, V]()
         for( (k, v) <- a.activeIterator) {
-          val vr = semiring./(v, b)
+          val vr = field.quot(v, b)
           r(k) = vr
         }
         r
@@ -212,7 +213,7 @@ trait Counter2Ops {
     val field = implicitly[Field[V]]
     def apply(a: Counter2[K1, K2, V], b: V) {
       for( (k,v) <- a.activeIterator) {
-        a(k) = field./(v, b)
+        a(k) = field.quot(v, b)
       }
     }
   }
@@ -316,5 +317,3 @@ trait Counter2Ops {
 
   implicit def zipMap[K1, K2, V, R:DefaultArrayValue:Semiring] = new CanZipMapValuesCounter2[K1, K2, V, R]
 }
-
-

--- a/src/main/scala/breeze/linalg/operators/CounterOps.scala
+++ b/src/main/scala/breeze/linalg/operators/CounterOps.scala
@@ -181,6 +181,8 @@ trait CounterOps {
                                field: Field[V],
                                d: DefaultArrayValue[V]):OpDiv.Impl2[Counter[K1, V], Counter[K1, V], Counter[K1, V]] = {
     new OpDiv.Impl2[Counter[K1, V], Counter[K1, V], Counter[K1, V]] {
+      private implicit val ring = new TemporaryFieldTranslation(field)
+
       override def apply(a : Counter[K1, V], b : Counter[K1, V]) = {
         val r = Counter[K1, V]()
         for( (k, v) <- a.activeIterator) {
@@ -197,6 +199,7 @@ trait CounterOps {
                                field: Field[V],
                                d: DefaultArrayValue[V]):OpDiv.Impl2[Counter[K1, V], V, Counter[K1, V]] = {
     new OpDiv.Impl2[Counter[K1, V], V, Counter[K1, V]] {
+      private implicit val ring = new TemporaryFieldTranslation(field)
       override def apply(a : Counter[K1, V], b : V) = {
         val r = Counter[K1, V]()
         for( (k, v) <- a.activeIterator) {

--- a/src/main/scala/breeze/linalg/operators/CounterOps.scala
+++ b/src/main/scala/breeze/linalg/operators/CounterOps.scala
@@ -1,10 +1,12 @@
 package breeze.linalg.operators
 
 import breeze.storage.DefaultArrayValue
-import breeze.math.{Field, Ring, Semiring}
+import breeze.math.{Ring, Semiring, TemporaryFieldTranslation}
 import breeze.linalg.support.{CanTransformValues, CanZipMapValues, CanAxpy, CanCopy}
 import breeze.generic.UFunc
 import breeze.linalg._
+import spire.algebra.Field
+import spire.implicits._
 
 trait CounterOps {
   implicit def canCopy[K1, V:DefaultArrayValue:Semiring]:CanCopy[Counter[K1, V]] = new CanCopy[Counter[K1, V]] {
@@ -169,20 +171,20 @@ trait CounterOps {
       val field = implicitly[Field[V]]
       def apply(a: Counter[K1, V], b: Counter[K1, V]) {
         for( (k,v) <- a.activeIterator) {
-          a(k) = field./(v, b(k))
+          a(k) = field.quot(v, b(k))
         }
       }
     }
   }
 
   implicit def canDivVV[K1, V](implicit copy: CanCopy[Counter[K1, V]],
-                               semiring: Field[V],
+                               field: Field[V],
                                d: DefaultArrayValue[V]):OpDiv.Impl2[Counter[K1, V], Counter[K1, V], Counter[K1, V]] = {
     new OpDiv.Impl2[Counter[K1, V], Counter[K1, V], Counter[K1, V]] {
       override def apply(a : Counter[K1, V], b : Counter[K1, V]) = {
         val r = Counter[K1, V]()
         for( (k, v) <- a.activeIterator) {
-          val vr = semiring./(v, b(k))
+          val vr = field.quot(v, b(k))
           r(k) = vr
         }
         r
@@ -192,13 +194,13 @@ trait CounterOps {
 
 
   implicit def canDivVS[K1, V](implicit copy: CanCopy[Counter[K1, V]],
-                               semiring: Field[V],
+                               field: Field[V],
                                d: DefaultArrayValue[V]):OpDiv.Impl2[Counter[K1, V], V, Counter[K1, V]] = {
     new OpDiv.Impl2[Counter[K1, V], V, Counter[K1, V]] {
       override def apply(a : Counter[K1, V], b : V) = {
         val r = Counter[K1, V]()
         for( (k, v) <- a.activeIterator) {
-          val vr = semiring./(v, b)
+          val vr = field.quot(v, b)
           r(k) = vr
         }
         r
@@ -210,7 +212,7 @@ trait CounterOps {
     val field = implicitly[Field[V]]
     def apply(a: Counter[K1, V], b: V) {
       for( (k,v) <- a.activeIterator) {
-        a(k) = field./(v, b)
+        a(k) = field.quot(v, b)
       }
     }
   }

--- a/src/main/scala/breeze/linalg/operators/DenseMatrixOps.scala
+++ b/src/main/scala/breeze/linalg/operators/DenseMatrixOps.scala
@@ -11,6 +11,7 @@ import breeze.linalg.support.{CanCollapseAxis, CanSlice2}
 import breeze.util.ArrayUtil
 import breeze.storage.DefaultArrayValue
 import scala.reflect.ClassTag
+import spire.implicits._
 
 trait DenseMatrixMultiplyStuff extends DenseMatrixOps with DenseMatrixMultOps { this: DenseMatrix.type =>
   implicit object DenseMatrixDMulDenseMatrixD

--- a/src/main/scala/breeze/linalg/operators/DenseVectorOps.scala
+++ b/src/main/scala/breeze/linalg/operators/DenseVectorOps.scala
@@ -10,6 +10,7 @@ import com.github.fommil.netlib.BLAS.{getInstance => blas}
 import breeze.macros.expand
 import scala.math.BigInt
 import breeze.math.PowImplicits._
+import spire.implicits._
 
 trait DenseVectorOps extends DenseVector_GenericOps { this: DenseVector.type =>
 

--- a/src/main/scala/breeze/linalg/operators/HashVectorOps.scala
+++ b/src/main/scala/breeze/linalg/operators/HashVectorOps.scala
@@ -9,6 +9,7 @@ import breeze.linalg.support.{CanZipMapValues, CanAxpy, CanCopy}
 import breeze.generic.UFunc.{UImpl, UImpl2}
 import scala.reflect.ClassTag
 import breeze.storage.DefaultArrayValue
+import spire.implicits._
 
 trait DenseVector_HashVector_Ops { this: HashVector.type =>
   import breeze.math.PowImplicits._

--- a/src/main/scala/breeze/linalg/operators/MatrixOps.scala
+++ b/src/main/scala/breeze/linalg/operators/MatrixOps.scala
@@ -9,6 +9,7 @@ import scala.util.Random
 import breeze.macros.expand
 import scala.math.BigInt
 import breeze.linalg._
+import spire.implicits._
 
 
 trait MatrixGenericOps { this: Matrix.type =>

--- a/src/main/scala/breeze/linalg/operators/OpType.scala
+++ b/src/main/scala/breeze/linalg/operators/OpType.scala
@@ -1,7 +1,8 @@
 package breeze.linalg.operators
 
 import breeze.generic.{MappingUFunc, UFunc}
-import breeze.math.{Field, Semiring, Ring}
+import breeze.math.{Semiring, Ring}
+import spire.algebra.Field
 
 /*
  Copyright 2012 Daniel Ramage
@@ -73,7 +74,7 @@ object OpMulScalar extends OpMulScalar with UFunc {
 sealed trait OpDiv extends OpType
 object OpDiv extends OpDiv with UFunc {
   implicit def opDivFromField[S:Field]: Impl2[S, S, S] = new Impl2[S, S, S] {
-    def apply(v: S, v2: S): S = implicitly[Field[S]]./(v, v2)
+    def apply(v: S, v2: S): S = implicitly[Field[S]].quot(v, v2)
   }
 }
 
@@ -264,4 +265,3 @@ object OpSolveMatrixBy extends OpSolveMatrixBy with UFunc
  */
 sealed trait OpMulMatrix extends OpType
 object OpMulMatrix extends OpMulMatrix with UFunc
-

--- a/src/main/scala/breeze/linalg/operators/SparseVectorOps.scala
+++ b/src/main/scala/breeze/linalg/operators/SparseVectorOps.scala
@@ -12,6 +12,7 @@ import scala.specialized
 import breeze.storage.DefaultArrayValue
 import breeze.generic.UFunc.UImpl
 import scala.{specialized=>spec}
+import spire.implicits._
 
 trait SparseVector_DenseVector_Ops extends DenseVector_SparseVector_Ops { this: SparseVector.type =>
   import breeze.math.PowImplicits._

--- a/src/main/scala/breeze/linalg/operators/VectorBuilderOps.scala
+++ b/src/main/scala/breeze/linalg/operators/VectorBuilderOps.scala
@@ -2,12 +2,13 @@ package breeze.linalg.operators
 
 import breeze.macros.expand
 import breeze.generic.UFunc.{UImpl2, InPlaceImpl2}
-import breeze.math.{Ring, MutableVectorSpace, Semiring}
+import breeze.math.{Ring, MutableVectorSpace, Semiring, BreezeFields}
 import breeze.storage.DefaultArrayValue
 import scala.reflect.ClassTag
 import breeze.linalg.support.CanAxpy
 import breeze.linalg._
-
+import spire.implicits._
+import BreezeFields._
 
 trait VectorBuilderOps { this: VectorBuilder.type =>
   @expand

--- a/src/main/scala/breeze/linalg/support/CanCopy.scala
+++ b/src/main/scala/breeze/linalg/support/CanCopy.scala
@@ -14,9 +14,9 @@ package breeze.linalg.support
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-import breeze.math.Field
 import breeze.util.ArrayUtil
 import scala.reflect.ClassTag
+import spire.algebra.Field
 
 /**
  * Capability trait for being able to copy a collection

--- a/src/main/scala/breeze/linalg/support/CanCreateZerosLike.scala
+++ b/src/main/scala/breeze/linalg/support/CanCreateZerosLike.scala
@@ -14,8 +14,9 @@ package breeze.linalg.support
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-import breeze.math.{Semiring, Field}
+import breeze.math.{Semiring}
 import scala.reflect.ClassTag
+import spire.algebra.Field
 
 
 /**
@@ -54,4 +55,3 @@ object CanCreateZerosLike {
   implicit object OpArrayF extends OpArray[Float]
   implicit object OpArrayD extends OpArray[Double]
 }
-

--- a/src/main/scala/breeze/math/Complex.scala
+++ b/src/main/scala/breeze/math/Complex.scala
@@ -18,6 +18,8 @@ import breeze.linalg.operators._
 import breeze.storage.DefaultArrayValue
 import scala.reflect.ClassTag
 import breeze.linalg.norm
+import spire.algebra._
+import spire.implicits._
 
 /**
  * Immutable complex number representation backed by doubles
@@ -110,8 +112,8 @@ case class Complex(real : Double, imag : Double) {
 
   def conjugate =
     Complex(real, -imag)
-    
-  def log = 
+
+  def log =
     Complex(math.log(abs), math.atan2(imag, real))
 
   def exp = {
@@ -120,7 +122,7 @@ case class Complex(real : Double, imag : Double) {
   }
 
   def pow(b: Double): Complex = pow(Complex(b, 0))
-  
+
   def pow(b: Complex): Complex = {
     if (b == Complex.zero) Complex.one
     else if (this == Complex.zero) {
@@ -143,6 +145,8 @@ case class Complex(real : Double, imag : Double) {
     case real : Float => this.real == real && this.imag == 0
     case _ => false
   }
+
+  def abs2: Double = real*real+imag*imag
 }
 
 object Complex { outer =>
@@ -211,7 +215,7 @@ object Complex { outer =>
   implicit val complexNorm: norm.Impl[Complex, Double] = new norm.Impl[Complex, Double] {
     def apply(v1: Complex): Double = v1.abs
   }
-  
+
   implicit object ComplexDefaultArrayValue extends DefaultArrayValue[Complex] {
     val value = Complex(0, 0)
   }
@@ -234,10 +238,10 @@ object Complex { outer =>
   { def apply(a : Int, b : Complex) = a + b}
 
   implicit object AddLC extends OpAdd.Impl2[Long, Complex, Complex]
-  { def apply(a : Long, b : Complex) = a + b}
+  { def apply(a : Long, b : Complex) = b + a}
 
   implicit object AddFC extends OpAdd.Impl2[Float, Complex, Complex]
-  { def apply(a : Float, b : Complex) = a + b}
+  { def apply(a : Float, b : Complex) = b + a}
 
   implicit object AddDC extends OpAdd.Impl2[Double, Complex, Complex]
   { def apply(a : Double, b : Complex) = a + b}
@@ -259,31 +263,31 @@ object Complex { outer =>
   //
 
   implicit object SubCC extends OpSub.Impl2[Complex, Complex, Complex]
-  { def apply(a : Complex, b : Complex) = a - b}
+  { def apply(a : Complex, b : Complex) = a-b}
 
   implicit object SubIC extends OpSub.Impl2[Int, Complex, Complex]
-  { def apply(a : Int, b : Complex) = a - b}
+  { def apply(a : Int, b : Complex) = Complex(a-b.real, -1*b.imag)}
 
   implicit object SubLC extends OpSub.Impl2[Long, Complex, Complex]
-  { def apply(a : Long, b : Complex) = a - b}
+  { def apply(a : Long, b : Complex) = Complex(a-b.real, -1*b.imag) }
 
   implicit object SubFC extends OpSub.Impl2[Float, Complex, Complex]
-  { def apply(a : Float, b : Complex) = a - b}
+  { def apply(a : Float, b : Complex) = Complex(a-b.real, -1*b.imag)}
 
   implicit object SubDC extends OpSub.Impl2[Double, Complex, Complex]
-  { def apply(a : Double, b : Complex) = a - b}
+  { def apply(a : Double, b : Complex) = Complex(a-b.real, -1*b.imag) }
 
   implicit object SubCI extends OpSub.Impl2[Complex, Int, Complex]
-  { def apply(a : Complex, b : Int) = a - b}
+  { def apply(a : Complex, b : Int) = Complex(a.real - b, a.imag)}
 
   implicit object SubCL extends OpSub.Impl2[Complex, Long, Complex]
-  { def apply(a : Complex, b : Long) = a - b}
+  { def apply(a : Complex, b : Long) = Complex(a.real-b, a.imag)}
 
   implicit object SubCF extends OpSub.Impl2[Complex, Float, Complex]
-  { def apply(a : Complex, b : Float) = a - b}
+  { def apply(a : Complex, b : Float) = Complex(a.real-b, a.imag)}
 
   implicit object SubCD extends OpSub.Impl2[Complex, Double, Complex]
-  { def apply(a : Complex, b : Double) = a - b}
+  { def apply(a : Complex, b : Double) = Complex(a.real-b, a.imag)}
 
   //
   // mul
@@ -296,25 +300,25 @@ object Complex { outer =>
   { def apply(a : Int, b : Complex) = a * b}
 
   implicit object MulLC extends OpMulMatrix.Impl2[Long, Complex, Complex]
-  { def apply(a : Long, b : Complex) = a * b}
+  { def apply(a : Long, b : Complex) = Complex(b.real*a, b.imag*a)}
 
   implicit object MulFC extends OpMulMatrix.Impl2[Float, Complex, Complex]
-  { def apply(a : Float, b : Complex) = a * b}
+  { def apply(a : Float, b : Complex) = Complex(b.real*a, b.imag*a)}
 
   implicit object MulDC extends OpMulMatrix.Impl2[Double, Complex, Complex]
-  { def apply(a : Double, b : Complex) = a * b}
+  { def apply(a : Double, b : Complex) = Complex(b.real*a, b.imag*a)}
 
   implicit object MulCI extends OpMulMatrix.Impl2[Complex, Int, Complex]
-  { def apply(a : Complex, b : Int) = a * b}
+  { def apply(a : Complex, b : Int) = Complex(a.real*b, a.imag*b)}
 
   implicit object MulCL extends OpMulMatrix.Impl2[Complex, Long, Complex]
-  { def apply(a : Complex, b : Long) = a * b}
+  { def apply(a : Complex, b : Long) = Complex(a.real*b, a.imag*b)}
 
   implicit object MulCF extends OpMulMatrix.Impl2[Complex, Float, Complex]
-  { def apply(a : Complex, b : Float) = a * b}
+  { def apply(a : Complex, b : Float) = Complex(a.real*b, a.imag*b)}
 
   implicit object MulCD extends OpMulMatrix.Impl2[Complex, Double, Complex]
-  { def apply(a : Complex, b : Double) = a * b}
+  { def apply(a : Complex, b : Double) = Complex(a.real*b, a.imag*b)}
 
   //
   // div
@@ -324,28 +328,28 @@ object Complex { outer =>
   { def apply(a : Complex, b : Complex) = a / b}
 
   implicit object DivIC extends OpDiv.Impl2[Int, Complex, Complex]
-  { def apply(a : Int, b : Complex) = a / b}
+  { def apply(a : Int, b : Complex) = Complex(a*b.real,-1*a*b.imag)/b.abs2}
 
   implicit object DivLC extends OpDiv.Impl2[Long, Complex, Complex]
-  { def apply(a : Long, b : Complex) = a / b}
+  { def apply(a : Long, b : Complex) = Complex(a*b.real,-1*a*b.imag)/b.abs2}
 
   implicit object DivFC extends OpDiv.Impl2[Float, Complex, Complex]
-  { def apply(a : Float, b : Complex) = a / b}
+  { def apply(a : Float, b : Complex) = Complex(a*b.real,-1*a*b.imag)/b.abs2}
 
   implicit object DivDC extends OpDiv.Impl2[Double, Complex, Complex]
-  { def apply(a : Double, b : Complex) = a / b}
+  { def apply(a : Double, b : Complex) = Complex(a*b.real,-1*a*b.imag)/b.abs2 }
 
   implicit object DivCI extends OpDiv.Impl2[Complex, Int, Complex]
-  { def apply(a : Complex, b : Int) = a / b}
+  { def apply(a : Complex, b : Int) = Complex(a.real/b, a.imag/b)}
 
   implicit object DivCL extends OpDiv.Impl2[Complex, Long, Complex]
-  { def apply(a : Complex, b : Long) = a / b}
+  { def apply(a : Complex, b : Long) = Complex(a.real/b, a.imag/b)}
 
   implicit object DivCF extends OpDiv.Impl2[Complex, Float, Complex]
-  { def apply(a: Complex, b : Float) = a / b}
+  { def apply(a: Complex, b : Float) = Complex(a.real/b, a.imag/b)}
 
   implicit object DivCD extends OpDiv.Impl2[Complex, Double, Complex]
-  { def apply(a : Complex, b : Double) = a / b}
+  { def apply(a : Complex, b : Double) = Complex(a.real/b, a.imag/b)}
 
   //
   // scala.math.Numeric and scala.math.Fractional
@@ -411,4 +415,3 @@ object Complex { outer =>
 //  }
 
 }
-

--- a/src/main/scala/breeze/math/Complex.scala
+++ b/src/main/scala/breeze/math/Complex.scala
@@ -190,13 +190,14 @@ object Complex { outer =>
     def <=(a : Complex, b : Complex) =
       (a.real <= b.real || (a.real == b.real && a.imag <= b.imag))
 
-    def +(a : Complex, b : Complex) = a + b
+    def plus(a : Complex, b : Complex) = a + b
 
-    def -(a : Complex, b : Complex) = a - b
+    def subtract(a : Complex, b : Complex) = a - b
 
-    def *(a : Complex, b : Complex) = a * b
+    def times(a : Complex, b : Complex) = a * b
 
-    def /(a : Complex, b : Complex) = a / b
+    def div(a : Complex, b : Complex) = a / b
+    def quot(a : Complex, b : Complex) = a / b
 
     def norm(a : Complex) = a.abs
 
@@ -210,6 +211,10 @@ object Complex { outer =>
 
     val defaultArrayValue = DefaultArrayValue(Complex(0, 0))
 
+    def negate(x: breeze.math.Complex): breeze.math.Complex = Complex(x.real, x.imag)
+    //These two are necessary to implement for spire. They will go away when we replace Complex with Spire's complex.
+    def gcd(a: breeze.math.Complex,b: breeze.math.Complex): breeze.math.Complex = ??? //Spire WTF is GCD of complex?
+    def mod(a: breeze.math.Complex,b: breeze.math.Complex): breeze.math.Complex = ??? //Spire WTF is GCD of complex?
   }
 
   implicit val complexNorm: norm.Impl[Complex, Double] = new norm.Impl[Complex, Double] {

--- a/src/main/scala/breeze/math/CoordinateSpace.scala
+++ b/src/main/scala/breeze/math/CoordinateSpace.scala
@@ -4,6 +4,7 @@ import breeze.linalg.support._
 import breeze.linalg.operators._
 import breeze.linalg.{norm, NumericOps}
 import spire.algebra._
+import spire.implicits._
 
 /**
  * A coordinate space is like a [[breeze.math.InnerProductSpace]], but
@@ -34,7 +35,7 @@ trait CoordinateSpace[V, S] extends InnerProductSpace[V, S] {
 object CoordinateSpace {
   implicit def fromField[S](implicit f: Field[S], _normImpl: norm.Impl[S, Double]):CoordinateSpace[S, S] = new CoordinateSpace[S, S] {
     def field: Field[S] = f
-
+    private implicit def ring = new TemporaryFieldTranslation(field)
 
     implicit def scalarNorm = _normImpl
 

--- a/src/main/scala/breeze/math/CoordinateSpace.scala
+++ b/src/main/scala/breeze/math/CoordinateSpace.scala
@@ -3,6 +3,7 @@ package breeze.math
 import breeze.linalg.support._
 import breeze.linalg.operators._
 import breeze.linalg.{norm, NumericOps}
+import spire.algebra._
 
 /**
  * A coordinate space is like a [[breeze.math.InnerProductSpace]], but

--- a/src/main/scala/breeze/math/Field.scala
+++ b/src/main/scala/breeze/math/Field.scala
@@ -31,12 +31,12 @@ trait MeasuresCloseness[T] {
 trait FakeField[T] extends Field[T]
 
 trait TemporaryTranslation {
-  implicit class TemporaryFieldTranslation[T](field: Field[T]) extends Ring[T] {
+  implicit class TemporaryFieldTranslation[T](ring: spire.algebra.Ring[T]) extends Ring[T] {
     //Here to translate Spire fields into Breeze rings, first step in eliminating breeze.math
-    def zero = field.zero
-    def one = field.one
-    def +(a: T, b: T) = field.plus(a,b)
-    def *(a: T, b: T) = field.times(a,b)
+    def zero = ring.zero
+    def one = ring.one
+    def +(a: T, b: T) = ring.plus(a,b)
+    def *(a: T, b: T) = ring.times(a,b)
   }
 }
 

--- a/src/main/scala/breeze/math/Field.scala
+++ b/src/main/scala/breeze/math/Field.scala
@@ -22,16 +22,29 @@ package breeze.math
  *
 *  @author dlwh
  */
-trait Field[@specialized(Int,Short,Long,Float,Double) V] extends Ring[V] {
-  def /(a : V, b : V) : V
-  def inverse(a: V) = /(one, a)
+import spire.algebra.Field
 
+trait MeasuresCloseness[T] {
+   def close(a: T, b: T, tolerance: Double): Boolean
 }
 
-object Field {
+trait FakeField[T] extends Field[T]
+
+trait TemporaryTranslation {
+  implicit class TemporaryFieldTranslation[T](field: Field[T]) extends Ring[T] {
+    //Here to translate Spire fields into Breeze rings, first step in eliminating breeze.math
+    def zero = field.zero
+    def one = field.one
+    def +(a: T, b: T) = field.plus(a,b)
+    def *(a: T, b: T) = field.times(a,b)
+  }
+}
+
+object BreezeFields {
+
   /** Not a field, but whatever. */
   @SerialVersionUID(1L)
-  implicit object fieldInt extends Field[Int] {
+  implicit object fieldInt extends FakeField[Int] {
     def zero = 0
     def one = 1
     def ==(a : Int, b : Int) = a == b
@@ -44,7 +57,7 @@ object Field {
 
   /** Not a field, but whatever. */
   @SerialVersionUID(1L)
-  implicit object fieldShort extends Field[Short] {
+  implicit object fieldShort extends FakeField[Short] {
     def zero = 0.asInstanceOf[Short]
     def one = 1.asInstanceOf[Short]
     def ==(a : Short, b : Short) = a == b
@@ -57,7 +70,7 @@ object Field {
 
   /** Not a field, but whatever. */
   @SerialVersionUID(1L)
-  implicit object fieldLong extends Field[Long] {
+  implicit object fieldLong extends FakeField[Long] {
     def zero = 0l
     def one = 1l
     def ==(a : Long, b : Long) = a == b
@@ -70,7 +83,7 @@ object Field {
 
   /** Not a field, but whatever. */
   @SerialVersionUID(1L)
-  implicit object fieldBigInt extends Field[BigInt] {
+  implicit object fieldBigInt extends FakeField[BigInt] {
     def zero = 0l
     def one = 1l
     def ==(a : BigInt, b : BigInt) = a == b
@@ -80,33 +93,4 @@ object Field {
     def *(a : BigInt, b : BigInt) = a * b
     def /(a : BigInt, b : BigInt) = a / b
   }
-
-  @SerialVersionUID(1L)
-  implicit object fieldFloat extends Field[Float] {
-    def zero = 0.0f
-    def one = 1.0f
-    def ==(a : Float, b : Float) = a == b
-    def !=(a : Float, b : Float) = a != b
-    def +(a : Float, b : Float) = a + b
-    def -(a : Float, b : Float) = a - b
-    def *(a : Float, b : Float) = a * b
-    def /(a : Float, b : Float) = a / b
-
-    override def close(a: Float, b: Float, tolerance: Double) = (a-b).abs <= math.max(a.abs, b.abs) * tolerance
-  }
-
-  @SerialVersionUID(-5955467582882664220L)
-  implicit object fieldD extends Field[Double] {
-    def zero = 0.0
-    def one = 1.0
-    def ==(a : Double, b : Double) = a == b
-    def !=(a : Double, b : Double) = a != b
-    def +(a : Double, b : Double) = a + b
-    def -(a : Double, b : Double) = a - b
-    def *(a : Double, b : Double) = a * b
-    def /(a : Double, b : Double) = a / b
-
-    override def close(a: Double, b: Double, tolerance: Double) = (a-b).abs <= math.max(a.abs, b.abs) * tolerance
-  }
 }
-

--- a/src/main/scala/breeze/math/Field.scala
+++ b/src/main/scala/breeze/math/Field.scala
@@ -30,7 +30,7 @@ trait MeasuresCloseness[T] {
 }
 
 trait FakeField[T] extends Field[T]
-class FakeFieldFromRing[T](ring: spire.algebra.EuclideanRing[T]) extends Field[T] {
+class FakeFieldFromRing[T](ring: spire.algebra.EuclideanRing[T]) extends FakeField[T] {
   // This is so wrong
   def zero = ring.zero
   def one = ring.one
@@ -51,8 +51,8 @@ trait TemporaryTranslation {
     def +(a: T, b: T) = ring.plus(a,b)
     def *(a: T, b: T) = ring.times(a,b)
     def -(a: T, b: T) = ring.minus(a,b)
-    def ==(a: T, b: T) = ring.==((a,b))
-    def !=(a: T, b: T) = ring.!=((a,b))
+    def ==(a: T, b: T): Boolean = (a == b)
+    def !=(a: T, b: T): Boolean = (a != b)
   }
 }
 

--- a/src/main/scala/breeze/math/Field.scala
+++ b/src/main/scala/breeze/math/Field.scala
@@ -23,20 +23,36 @@ package breeze.math
 *  @author dlwh
  */
 import spire.algebra.Field
+import spire.implicits._
 
 trait MeasuresCloseness[T] {
    def close(a: T, b: T, tolerance: Double): Boolean
 }
 
 trait FakeField[T] extends Field[T]
+class FakeFieldFromRing[T](ring: spire.algebra.EuclideanRing[T]) extends Field[T] {
+  // This is so wrong
+  def zero = ring.zero
+  def one = ring.one
+  def plus(a: T, b: T) = ring.plus(a,b)
+  def times(a: T, b: T) = ring.times(a,b)
+  def negate(a: T) = ring.negate(a)
+  def div(a: T, b: T) = ring.quot(a,b)
+  def mod(a: T, b: T) = ring.mod(a,b)
+  def gcd(a: T, b: T) = ring.gcd(a,b)
+  def quot(a: T, b: T) = ring.quot(a,b)
+}
 
 trait TemporaryTranslation {
-  implicit class TemporaryFieldTranslation[T](ring: spire.algebra.Ring[T]) extends Ring[T] {
+  implicit class TemporaryFieldTranslation[T](ring: spire.algebra.EuclideanRing[T]) extends Ring[T] {
     //Here to translate Spire fields into Breeze rings, first step in eliminating breeze.math
     def zero = ring.zero
     def one = ring.one
     def +(a: T, b: T) = ring.plus(a,b)
     def *(a: T, b: T) = ring.times(a,b)
+    def -(a: T, b: T) = ring.minus(a,b)
+    def ==(a: T, b: T) = ring.==((a,b))
+    def !=(a: T, b: T) = ring.!=((a,b))
   }
 }
 
@@ -44,53 +60,17 @@ object BreezeFields {
 
   /** Not a field, but whatever. */
   @SerialVersionUID(1L)
-  implicit object fieldInt extends FakeField[Int] {
-    def zero = 0
-    def one = 1
-    def ==(a : Int, b : Int) = a == b
-    def !=(a : Int, b : Int) = a != b
-    def +(a : Int, b : Int) = a + b
-    def -(a : Int, b : Int) = a - b
-    def *(a : Int, b : Int) = a * b
-    def /(a : Int, b : Int) = a / b
-  }
+  implicit object fieldInt extends FakeFieldFromRing(spire.std.int.IntAlgebra)
 
   /** Not a field, but whatever. */
   @SerialVersionUID(1L)
-  implicit object fieldShort extends FakeField[Short] {
-    def zero = 0.asInstanceOf[Short]
-    def one = 1.asInstanceOf[Short]
-    def ==(a : Short, b : Short) = a == b
-    def !=(a : Short, b : Short) = a != b
-    def +(a : Short, b : Short) = (a + b).asInstanceOf[Short]
-    def -(a : Short, b : Short) = (a - b).asInstanceOf[Short]
-    def *(a : Short, b : Short) = (a * b).asInstanceOf[Short]
-    def /(a : Short, b : Short) = (a / b).asInstanceOf[Short]
-  }
+  implicit object fieldShort extends FakeFieldFromRing(spire.std.short.ShortAlgebra)
 
   /** Not a field, but whatever. */
   @SerialVersionUID(1L)
-  implicit object fieldLong extends FakeField[Long] {
-    def zero = 0l
-    def one = 1l
-    def ==(a : Long, b : Long) = a == b
-    def !=(a : Long, b : Long) = a != b
-    def +(a : Long, b : Long) = a + b
-    def -(a : Long, b : Long) = a - b
-    def *(a : Long, b : Long) = a * b
-    def /(a : Long, b : Long) = a / b
-  }
+  implicit object fieldLong extends FakeFieldFromRing(spire.std.long.LongAlgebra)
 
   /** Not a field, but whatever. */
   @SerialVersionUID(1L)
-  implicit object fieldBigInt extends FakeField[BigInt] {
-    def zero = 0l
-    def one = 1l
-    def ==(a : BigInt, b : BigInt) = a == b
-    def !=(a : BigInt, b : BigInt) = a != b
-    def +(a : BigInt, b : BigInt) = a + b
-    def -(a : BigInt, b : BigInt) = a - b
-    def *(a : BigInt, b : BigInt) = a * b
-    def /(a : BigInt, b : BigInt) = a / b
-  }
+  implicit object fieldBigInt extends FakeFieldFromRing(spire.std.bigInt.BigIntAlgebra)
 }

--- a/src/main/scala/breeze/math/MutablizingAdaptor.scala
+++ b/src/main/scala/breeze/math/MutablizingAdaptor.scala
@@ -6,6 +6,8 @@ import breeze.linalg.operators._
 import breeze.util.Isomorphism
 import breeze.generic.{UFunc}
 import breeze.generic.UFunc.UImpl2
+import spire.algebra._
+import spire.implicits._
 
 /**
  *

--- a/src/main/scala/breeze/math/PowImplicits.scala
+++ b/src/main/scala/breeze/math/PowImplicits.scala
@@ -10,20 +10,8 @@ import breeze.numerics.IntMath
 object PowImplicits {
   // just to make some unrolling less terrible
   // TODO: move this somewhere sensible
-  implicit class DoublePow(x: Double) {
-    def pow(y: Double) = math.pow(x,y)
-  }
 
   implicit class FloatPow(x: Float) {
     def pow(y: Float) = math.pow(x,y).toFloat
   }
-
-  implicit class IntPow(x: Int) {
-    def pow(y: Int) = IntMath.ipow(x, y)
-  }
-
-  implicit class LongPow(x: Long) {
-    def pow(y: Long) = IntMath.ipow(x, y)
-  }
-
 }

--- a/src/main/scala/breeze/math/Ring.scala
+++ b/src/main/scala/breeze/math/Ring.scala
@@ -20,6 +20,9 @@ package breeze.math
  * @author dlwh
  */
 
+import spire.algebra._
+import spire.implicits._
+
 trait Ring[@specialized(Int,Short,Long,Float,Double) V] extends Semiring[V]  {
 
   def -(a : V, b : V) : V
@@ -28,9 +31,9 @@ trait Ring[@specialized(Int,Short,Long,Float,Double) V] extends Semiring[V]  {
 }
 
 object Ring {
-  import Field._
-  implicit val ringD: Ring[Double] = fieldD
-  implicit val ringFloat: Ring[Float] = fieldFloat
+  import BreezeFields._
+  implicit val ringD: Ring[Double] = new TemporaryFieldTranslation(implicitly[Field[Double]])
+  implicit val ringFloat: Ring[Float] = new TemporaryFieldTranslation(implicitly[Field[Float]])
   implicit val ringInt: Ring[Int] = fieldInt
   implicit val ringLong: Ring[Long] = fieldLong
   implicit val ringBigInt: Ring[BigInt] = fieldBigInt

--- a/src/main/scala/breeze/math/VectorSpace.scala
+++ b/src/main/scala/breeze/math/VectorSpace.scala
@@ -18,6 +18,8 @@ package breeze.math
 import breeze.linalg.operators._
 import breeze.linalg.support._
 import breeze.linalg.{norm, QuasiTensor, NumericOps}
+import spire.algebra.Field
+import spire.implicits._
 
 /**
  *

--- a/src/main/scala/breeze/math/package.scala
+++ b/src/main/scala/breeze/math/package.scala
@@ -20,7 +20,4 @@ package breeze
  * @author dlwh
  */
 package object math extends TemporaryTranslation {
-  val i = Complex.i
-
-
 }

--- a/src/main/scala/breeze/math/package.scala
+++ b/src/main/scala/breeze/math/package.scala
@@ -20,4 +20,5 @@ package breeze
  * @author dlwh
  */
 package object math extends TemporaryTranslation {
+  val i = Complex(0,1)
 }

--- a/src/main/scala/breeze/math/package.scala
+++ b/src/main/scala/breeze/math/package.scala
@@ -19,26 +19,8 @@ package breeze
  *
  * @author dlwh
  */
-package object math {
+package object math extends TemporaryTranslation {
   val i = Complex.i
 
-  class RichField(value : Double) {
-    def + (c : Complex) : Complex = Complex(value,0) + c
-    def - (c : Complex) : Complex = Complex(value,0) - c
-    def * (c : Complex) : Complex = Complex(value,0) * c
-    def / (c : Complex) : Complex = Complex(value,0) / c
-  }
 
-  implicit def richInt(value : Int) =
-    new RichField(value)
-
-  implicit def richLong(value : Long) =
-    new RichField(value)
-
-  implicit def richFloat(value : Float) =
-    new RichField(value)
-
-  implicit def richDouble(value : Double) =
-    new RichField(value)
 }
-

--- a/src/main/scala/breeze/stats/DescriptiveStats.scala
+++ b/src/main/scala/breeze/stats/DescriptiveStats.scala
@@ -41,7 +41,7 @@ trait DescriptiveStatsTrait {
           }
 
           def zeros(numZero: Int, zeroValue: Scalar): Unit = {
-            sum += (numZero * zeroValue)
+            sum += (zeroValue * numZero)
             n += numZero
           }
         }

--- a/src/main/scala/breeze/stats/distributions/Bernoulli.scala
+++ b/src/main/scala/breeze/stats/distributions/Bernoulli.scala
@@ -4,6 +4,8 @@ package distributions
 import breeze.linalg.Counter
 import breeze.numerics._
 import breeze.optimize.DiffFunction
+import spire.algebra._
+import spire.implicits._
 
 /*
  Copyright 2009 David Hall, Daniel Ramage
@@ -31,7 +33,7 @@ class Bernoulli(p: Double, rand: RandBasis = Rand) extends DiscreteDistr[Boolean
   require(p >= 0.0)
   require(p <= 1.0)
   def probabilityOf(b: Boolean) = if(b) p else (1-p)
-  
+
   override def draw() = {
     rand.uniform.get < p
   }

--- a/src/main/scala/breeze/stats/distributions/Dirichlet.scala
+++ b/src/main/scala/breeze/stats/distributions/Dirichlet.scala
@@ -23,6 +23,8 @@ import breeze.linalg.operators.{OpDiv, BinaryOp}
 import breeze.math.{TensorSpace, MutableCoordinateSpace}
 import breeze.numerics
 import breeze.storage.DefaultArrayValue
+import spire.algebra._
+import spire.implicits._
 
 /**
  * Represents a Dirichlet distribution, the conjugate prior to the multinomial.

--- a/src/main/scala/breeze/stats/distributions/Polya.scala
+++ b/src/main/scala/breeze/stats/distributions/Polya.scala
@@ -4,6 +4,8 @@ import breeze.linalg.{sum, Counter, NumericOps}
 import breeze.math.{TensorSpace, MutableCoordinateSpace}
 import breeze.numerics._
 import breeze.storage.DefaultArrayValue
+import spire.algebra._
+import spire.implicits._
 
 
 /*
@@ -24,7 +26,7 @@ import breeze.storage.DefaultArrayValue
 
 /**
  * Represents a Polya distribution, a.k.a Dirichlet compound Multinomial distribution
- * see 
+ * see
  * http://en.wikipedia.org/wiki/Multivariate_Polya_distribution
  *
  * @author dlwh

--- a/src/test/scala/breeze/linalg/Counter2Test.scala
+++ b/src/test/scala/breeze/linalg/Counter2Test.scala
@@ -18,6 +18,7 @@ import org.scalatest._
 import org.scalatest.junit._
 import org.scalatest.prop._
 import org.junit.runner.RunWith
+import spire.std.double._
 
 @RunWith(classOf[JUnitRunner])
 class Counter2Test extends FunSuite with Checkers {

--- a/src/test/scala/breeze/optimize/LBFGSTest.scala
+++ b/src/test/scala/breeze/optimize/LBFGSTest.scala
@@ -1,18 +1,18 @@
 package breeze.optimize
 /*
  Copyright 2009 David Hall, Daniel Ramage
- 
+
  Licensed under the Apache License, Version 2.0 (the "License")
  you may not use this file except in compliance with the License.
- You may obtain a copy of the License at 
- 
+ You may obtain a copy of the License at
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
 
 import org.scalatest._
@@ -20,7 +20,7 @@ import org.scalatest.junit._
 import org.scalatest.prop._
 import org.scalacheck._
 import org.junit.runner.RunWith
-
+import spire.std.double._
 import breeze.linalg._
 
 @RunWith(classOf[JUnitRunner])
@@ -36,7 +36,7 @@ class LBFGSTest extends OptimizeTestBase {
         }
       }
 
-      val result = lbfgs.minimize(f,init) 
+      val result = lbfgs.minimize(f,init)
       norm(result - 3.0,2) < 1E-10
     }
 
@@ -127,4 +127,3 @@ class LBFGSTest extends OptimizeTestBase {
 
 
 }
-

--- a/src/test/scala/breeze/optimize/OWLQNTest.scala
+++ b/src/test/scala/breeze/optimize/OWLQNTest.scala
@@ -21,7 +21,7 @@ import org.scalatest.junit._
 import org.scalatest.prop._
 import org.scalacheck._
 import org.junit.runner.RunWith
-
+import spire.std.double._
 import breeze.linalg._
 
 

--- a/src/test/scala/breeze/optimize/StochasticGradientDescentTest.scala
+++ b/src/test/scala/breeze/optimize/StochasticGradientDescentTest.scala
@@ -1,18 +1,18 @@
 package breeze.optimize
 /*
  Copyright 2009 David Hall, Daniel Ramage
- 
+
  Licensed under the Apache License, Version 2.0 (the "License")
  you may not use this file except in compliance with the License.
- You may obtain a copy of the License at 
- 
+ You may obtain a copy of the License at
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
 
 import org.scalatest._
@@ -21,7 +21,7 @@ import org.scalatest.prop._
 import org.scalacheck._
 import org.junit.runner.RunWith
 import breeze.linalg._
-
+import spire.std.double._
 
 @RunWith(classOf[JUnitRunner])
 class StochasticGradientDescentTest extends OptimizeTestBase {
@@ -39,7 +39,7 @@ class StochasticGradientDescentTest extends OptimizeTestBase {
         val fullRange = 0 to 1
       }
 
-      val result = sgd.minimize(f,init) 
+      val result = sgd.minimize(f,init)
       norm(result :- DenseVector.ones[Double](init.size) * 3.0,2) < 1E-10
     }
 

--- a/src/test/scala/breeze/optimize/TruncatedNewtonMinimizerTest.scala
+++ b/src/test/scala/breeze/optimize/TruncatedNewtonMinimizerTest.scala
@@ -19,7 +19,7 @@ package breeze.optimize
 import org.scalatest.junit._
 import org.scalacheck._
 import org.junit.runner.RunWith
-
+import spire.std.double._
 import breeze.linalg._
 
 @RunWith(classOf[JUnitRunner])


### PR DESCRIPTION
So I decided to take a look at #21, specifically porting breeze over to use Spire's Field implementation. I'm leaving Ring and Semiring alone for the moment, and converting Spire Fields to Breeze Semirings via an implicit. Obviously in the long run, everything would need to be ported over. 

I've got all the code, and most of the tests compiling. Most of the tests pass as well if I delete the one file that doesn't compile. The main source of failing tests seems to be "dot product distributes". 

I'd be curious to get some thoughts on this. Is this the right way to go? Is there a simpler way to do it? Anyone see a solution for the failing tests or the one that doesn't compile? (I've been beating my head against it all day.)
