### PR TITLE
slice of DenseVector

### DIFF
--- a/src/main/scala/breeze/linalg/DenseVector.scala
+++ b/src/main/scala/breeze/linalg/DenseVector.scala
@@ -188,7 +188,7 @@ class DenseVector[@spec(Double, Int, Float) E](val data: Array[E],
   def slice(start: Int, end: Int, stride: Int=1):DenseVector[E] = {
     if(start > end || start < 0) throw new IllegalArgumentException("Slice arguments " + start +", " +end +" invalid.")
     if(end > length || end < 0) throw new IllegalArgumentException("End " + end + "is out of bounds for slice of DenseVector of length " + length)
-    new DenseVector(data, start + offset, stride * this.stride, (end-start)/stride)
+    new DenseVector(data, start * this.stride + offset, stride * this.stride, (end-start)/stride)
   }
 
   override def toArray(implicit cm: ClassTag[E]) = if(stride == 1){
@@ -412,7 +412,7 @@ object DenseVector extends VectorConstructors[DenseVector] with DenseVector_Gene
 
         require(r.isEmpty || r.last < v.length)
         require(r.isEmpty || r.start >= 0)
-        new DenseVector(v.data, offset = v.offset + r.start, stride = v.stride * r.step, length = r.length)
+        new DenseVector(v.data, offset = v.offset + v.stride * r.start, stride = v.stride * r.step, length = r.length)
       }
     }
   }


### PR DESCRIPTION
```
scala> import breeze.linalg.DenseVector
scala> val dvec = DenseVector((0 to 15).toArray)(0 to 15 by 3)
dvec: breeze.linalg.DenseVector[Int] = DenseVector(0, 3, 6, 9, 12, 15)

scala> dvec(1 to 5 by 2)
res0: breeze.linalg.DenseVector[Int] = DenseVector(1, 7, 13)
```

I expect that dvec(1 to 5 by 2) = DenseVector(3, 9, 15).
If I understand slice correctly, argument "start" should be multiplied by field "stride".
