### PR TITLE
Don't rely on fixed Scala bug with inherited private fields

### DIFF
--- a/src/main/scala/breeze/collection/mutable/Beam.scala
+++ b/src/main/scala/breeze/collection/mutable/Beam.scala
@@ -32,7 +32,7 @@ import scala.collection.generic._
 class Beam[T](val maxSize:Int, xs:T*)(implicit o : Ordering[T]) extends Iterable[T] 
     with IterableLike[T,Beam[T]]  with Growable[T] { outer =>
   assert(maxSize >= 0)
-  private val queue = new PriorityQueue[T]()(o.reverse)
+  protected val queue = new PriorityQueue[T]()(o.reverse)
   xs foreach (cat(queue,_))
 
   override def size = queue.size


### PR DESCRIPTION
See https://issues.scala-lang.org/browse/SI-7475.

```
class C { s1 =>
  private val q = ... // privates should not be inherited!

  new C { s2 =>
    // in Scala 2.11, this binds to s1.q, in 2.10 it buggily bound to `s2.q`
    q
  }
}
```
