### PR TITLE
do not use BitSet.valueOf which is java 7 only

### DIFF
--- a/src/main/scala/breeze/util/package.scala
+++ b/src/main/scala/breeze/util/package.scala
@@ -197,7 +197,9 @@ package object util {
 
   implicit class AwesomeScalaBitSet(val bs: scala.collection.BitSet) extends AnyVal {
     def toJavaBitSet = {
-      java.util.BitSet.valueOf(bs.toBitMask)
+      val jbs = new java.util.BitSet(bs.lastOption.getOrElse(0) + 1)
+      bs.foreach(jbs.set(_))
+      jbs
     }
   }
 


### PR DESCRIPTION
a few projects i care about (spark and hadoop based projects) are about to introduce breeze dependencies, but they require java 6 compatibility
