### PR TITLE
fix for serialization issue in kryo (stackoverflow error)

### DIFF
--- a/src/main/scala/breeze/linalg/DenseVector.scala
+++ b/src/main/scala/breeze/linalg/DenseVector.scala
@@ -77,11 +77,8 @@ class DenseVector[@spec(Double, Int, Float) E](val data: Array[E],
     data(offset + trueI * stride) = v
   }
 
-  //I have no fucking clue why this speeds things up, but it does seem to.
-  //private final val innerUpdate: ((Int,E) => Unit) = if ((offset == 0) && (stride == 1)) { (i:Int,v:E) => {data(i) = v} } else {(i:Int,v:E) => {data(offset+i*stride)=v}  }
-
   private val noOffsetOrStride = offset == 0 && stride == 1
-  def unsafeUpdate(i: Int, v: E) = if (noOffsetOrStride) data(i) = v else data(offset+i*stride) = v // innerUpdate(i,v) //data(offset + i * stride) = v
+  def unsafeUpdate(i: Int, v: E) = if (noOffsetOrStride) data(i) = v else data(offset+i*stride) = v
 
   def activeIterator = iterator
 


### PR DESCRIPTION
Both Spark and Scalding use Kryo (with reference tracking turned off) for serialization. I have been testing which breeze classes roundtrip Kryo serialization without issues. So far SparseVector, HashVector, DenseMatrix, and SliceVector all pass, but DenseVector causes a stackoverflow in Kryo. The issue with DenseVector is innerUpdate, which references back to variables in DenseVector and causes an infinite loop i guess in the serialization process. So i tried to modify it in such a way that it works with Kryo. 

Not sure if this is acceptable from a performance perspective.
