### PR TITLE
Minor performance improvements for Rand.condition

### DIFF
--- a/benchmark/src/main/scala/breeze/stats/ProbMonad.scala
+++ b/benchmark/src/main/scala/breeze/stats/ProbMonad.scala
@@ -14,7 +14,7 @@ class ProbMonadBenchmark extends BreezeBenchmark {
   val fm: Double => Rand[Double] = (x => Uniform(min(x,2*x), max(x,2*x)))
   val gaussian = Gaussian(0,1)
 
-  val size = 1024*1024
+  val size = 1024*1024*8
 
   def timeMap(reps: Int) = run(reps) {
     val mg = gaussian.map(f)
@@ -34,6 +34,23 @@ class ProbMonadBenchmark extends BreezeBenchmark {
   def timeRepeatCondition(reps: Int) = run(reps) {
     val mg = gaussian.condition(x => x > 0).condition(x => x < 1).condition(x => x > -1)
     mg.samplesVector(size)
+  }
+
+  def timeDrawOpt(reps: Int) = run(reps) {
+    val mg = gaussian.condition(x => x > 0)
+    val result = new Array[Option[Double]](size)
+    cfor(0)(i => i<size, i=>i+1)(i => {
+      result(i) = mg.drawOpt()
+    })
+    result
+  }
+  def timeDrawOptMultipleCondition(reps: Int) = run(reps) {
+    val mg = gaussian.condition(x => x > 0).condition(x => x < 1).condition(x => x > -1)
+    val result = new Array[Option[Double]](size)
+    cfor(0)(i => i<size, i=>i+1)(i => {
+      result(i) = mg.drawOpt()
+    })
+    result
   }
 
 }

--- a/math/src/main/scala/breeze/stats/distributions/Rand.scala
+++ b/math/src/main/scala/breeze/stats/distributions/Rand.scala
@@ -137,7 +137,8 @@ private final case class SinglePredicate[@specialized(Int, Double) T](rand: Rand
     MultiplePredicates(rand, newPredicates)
   }
 
-  def draw() = {
+  def draw() = { // Not the most efficient implementation ever, but meh.
+
     var x = rand.draw()
     while(!predicate(x)) {
       x = rand.draw()
@@ -146,7 +147,12 @@ private final case class SinglePredicate[@specialized(Int, Double) T](rand: Rand
   }
 
   override def drawOpt() = {
-    Some(rand.get()).filter(predicate)
+    val x = rand.get()
+    if (predicate(x)) {
+      Some(x)
+    } else {
+      None
+    }
   }
 }
 
@@ -170,7 +176,7 @@ private final case class MultiplePredicates[@specialized(Int, Double) T](rand: R
     result
   }
 
-  def draw() = {
+  def draw() = {// Not the most efficient implementation ever, but meh.
     var x = rand.draw()
     while(!p(x)) {
       x = rand.draw()
@@ -179,7 +185,12 @@ private final case class MultiplePredicates[@specialized(Int, Double) T](rand: R
   }
 
   override def drawOpt() = {
-    Some(rand.get()).filter(p _)
+    val x = rand.get()
+    if (p(x)) {
+      Some(x)
+    } else {
+      None
+    }
   }
 }
 


### PR DESCRIPTION
Added some benchmarks. Before:

[info] Running breeze.linalg.ProbMonadRunner 
[info]  0% Scenario{vm=java, trial=0, benchmark=Map} 133255769.33 ns; σ=1180506.86 ns @ 3 trials
[info] 25% Scenario{vm=java, trial=0, benchmark=FlatMap} 114747129.08 ns; σ=1142942.59 ns @ 6 trials
[info] 50% Scenario{vm=java, trial=0, benchmark=Condition} 163731247.33 ns; σ=1173484.00 ns @ 3 trials
[info] 75% Scenario{vm=java, trial=0, benchmark=RepeatCondition} 307967589.50 ns; σ=1495141.27 ns @ 3 trials
[info] 
[info]       benchmark  ms linear runtime
[info]             Map 133 ============
[info]         FlatMap 115 ===========
[info]       Condition 164 ===============
[info] RepeatCondition 308 ==============================

After:

[info] Running breeze.linalg.ProbMonadRunner 
[info]  0% Scenario{vm=java, trial=0, benchmark=Map} 133609547.43 ns; σ=1262758.71 ns @ 10 trials
[info] 25% Scenario{vm=java, trial=0, benchmark=FlatMap} 115288567.29 ns; σ=773792.55 ns @ 3 trials
[info] 50% Scenario{vm=java, trial=0, benchmark=Condition} 162809875.22 ns; σ=595432.81 ns @ 3 trials
[info] 75% Scenario{vm=java, trial=0, benchmark=RepeatCondition} 277582390.40 ns; σ=1227784.94 ns @ 3 trials
[info] 
[info]       benchmark  ms linear runtime
[info]             Map 134 ==============
[info]         FlatMap 115 ============
[info]       Condition 163 =================
[info] RepeatCondition 278 ==============================

The improvement comes in condition - rather than having a nested sequence of inner classes each of which tracks a single predicate, we just have one class that stores a list of the predicates. When we add new conditions, we just add to the list of predicates. 
