### PR TITLE
remove scalalogging from dependencies

### DIFF
--- a/math/build.sbt
+++ b/math/build.sbt
@@ -57,6 +57,7 @@ libraryDependencies ++= Seq(
   "com.github.rwl" % "jtransforms" % "2.4.0",
   "org.apache.commons" % "commons-math3" % "3.2",
   "org.spire-math" %% "spire" % "0.7.4",
+  "org.slf4j" % "slf4j-api" % "1.7.5",
   "org.scalacheck" %% "scalacheck" % "1.11.3" % "test",
   "org.scalatest" %% "scalatest" % "2.1.3" % "test",
   "org.scala-lang.modules" % "scala-xml_2.11" % "1.0.1" % "test",
@@ -68,11 +69,9 @@ libraryDependencies ++= Seq(
 libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) =>
   sv match {
     case x if x startsWith "2.10" =>
-      (deps :+ ("com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2")
-           :+ ("com.chuusai" %% "shapeless" % "2.0.0" % "test" cross CrossVersion.full))
+      (deps :+ ("com.chuusai" %% "shapeless" % "2.0.0" % "test" cross CrossVersion.full))
     case x if x.startsWith("2.11") =>
-      (deps :+ ("com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2")
-           :+ ("com.chuusai" %% "shapeless" % "2.0.0" % "test"  ))
+      (deps :+ ("com.chuusai" %% "shapeless" % "2.0.0" % "test"  ))
     case _       =>
       deps
   }

--- a/math/src/main/scala/breeze/linalg/operators/CSCMatrixOps.scala
+++ b/math/src/main/scala/breeze/linalg/operators/CSCMatrixOps.scala
@@ -278,7 +278,7 @@ trait CSCMatrixOps extends CSCMatrixOpsLowPrio {  this: CSCMatrix.type =>
         require(rows == b.rows, "Matrices must have same number of rows!")
         require(cols == b.cols, "Matrices must have same number of cols!")
 
-        if (cols == 0 || rows == 0) return Unit
+        if (cols == 0 || rows == 0) return
 
         var ci      = 0             // column index [0 ... cols)
         var apStop  = a.colPtrs(0)  // pointer into row indices and data

--- a/math/src/main/scala/breeze/optimize/GradientTester.scala
+++ b/math/src/main/scala/breeze/optimize/GradientTester.scala
@@ -4,7 +4,7 @@ import breeze.linalg.support.CanCopy
 import breeze.linalg.{norm, Tensor, NumericOps}
 import breeze.linalg.operators.{OpSub, BinaryOp}
 import breeze.stats.distributions.Rand
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import breeze.util.SerializableLogging
 
 /**
  * Class that compares the computed gradient with an empirical gradient based on
@@ -12,7 +12,7 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
  *
  * @author dlwh
  */
-object GradientTester extends LazyLogging {
+object GradientTester extends SerializableLogging {
   /**
    * Tests a gradient by comparing the gradient to the empirically calculated gradient from finite differences,
    * returning those that are bad, logging bad ones on WARN, ok ones on DEBUG, and overall statistics on INFO.

--- a/math/src/main/scala/breeze/signal/support/CanConvolve.scala
+++ b/math/src/main/scala/breeze/signal/support/CanConvolve.scala
@@ -11,7 +11,7 @@ import breeze.signal.OptRange.RangeOpt
 import breeze.numerics.isOdd
 import breeze.signal.OptRange.RangeOpt
 import scala.reflect.ClassTag
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import breeze.util.SerializableLogging
 
 //ToDo 1: provide convolve of Integer and other DenseVectors
 //ToDo 1: provide convolve of DenseMatrix
@@ -41,7 +41,7 @@ trait CanConvolve[Input, KernelType, Output] {
  *
  * @author ktakagaki
  */
-object CanConvolve extends LazyLogging {
+object CanConvolve extends SerializableLogging {
 
   @expand
   @expand.valify
@@ -186,8 +186,7 @@ object CanConvolve extends LazyLogging {
         require( data.length * kernel.length != 0, "data and kernel must be non-empty DenseVectors")
         require( data.length >= kernel.length, "kernel (" + kernel.length + ") cannot be longer than data(" + data.length + ") to be convolved/correlated!")
         require( range.start >= 0 && range.last <= (data.length - kernel.length + 1),
-          logger.error("range (start {}, end {}, step {}, inclusive {}) is OOB for data (length {}) and kernel (length {})!",
-            range.start.toString, range.end.toString, range.step.toString, range.isInclusive.toString, data.length.toString, kernel.length.toString )
+          logger.error(s"range (start ${range.start}, end ${range.end}, step ${range.step}, inclusive ${range.isInclusive}) is OOB for data (length ${data.length}) and kernel (length ${kernel.length})!")
         )
 
         val dataVect = data.toScalaVector() //make immutable
@@ -217,8 +216,7 @@ object CanConvolve extends LazyLogging {
         require( data.length * kernel.length != 0, "data and kernel must be non-empty DenseVectors")
         require( data.length >= kernel.length, "kernel cannot be longer than data to be convolved/corelated!")
         require( range.start >= 0 && range.last <= (data.length - kernel.length + 1),
-          logger.error("range (start {}, end {}, step {}, inclusive {}) is OOB for data (length {}) and kernel (length {})!",
-            range.start.toString, range.end.toString, range.step.toString, range.isInclusive.toString, data.length.toString, kernel.length.toString )
+          logger.error(s"range (start ${range.start}, end ${range.end}, step ${range.step}, inclusive ${range.isInclusive}) is OOB for data (length ${data.length}) and kernel (length ${kernel.length})!")
         )
 
         val dataL = convert(data, Long).toScalaVector() //make immutable

--- a/math/src/main/scala/breeze/util/Logger.scala
+++ b/math/src/main/scala/breeze/util/Logger.scala
@@ -1,0 +1,49 @@
+package breeze.util
+
+import org.slf4j.Logger
+
+/**
+ * A logger that only evaluates parameters lazily if the corresponding log level is enabled.
+ */
+class LazyLogger(log: Logger) extends Serializable {
+
+  def info(msg: => String) {
+    if (log.isInfoEnabled) log.info(msg)
+  }
+
+  def debug(msg: => String) {
+    if (log.isDebugEnabled) log.debug(msg)
+  }
+
+  def trace(msg: => String) {
+    if (log.isTraceEnabled) log.trace(msg)
+  }
+
+  def warn(msg: => String) {
+    if (log.isWarnEnabled) log.warn(msg)
+  }
+
+  def error(msg: => String) {
+    if (log.isErrorEnabled) log.error(msg)
+  }
+
+  def info(msg: => String, throwable: Throwable) {
+    if (log.isInfoEnabled) log.info(msg, throwable)
+  }
+
+  def debug(msg: => String, throwable: Throwable) {
+    if (log.isDebugEnabled) log.debug(msg, throwable)
+  }
+
+  def trace(msg: => String, throwable: Throwable) {
+    if (log.isTraceEnabled) log.trace(msg, throwable)
+  }
+
+  def warn(msg: => String, throwable: Throwable) {
+    if (log.isWarnEnabled) log.warn(msg, throwable)
+  }
+
+  def error(msg: => String, throwable: Throwable) {
+    if (log.isErrorEnabled) log.error(msg, throwable)
+  }
+}

--- a/math/src/main/scala/breeze/util/SerializableLogging.scala
+++ b/math/src/main/scala/breeze/util/SerializableLogging.scala
@@ -1,8 +1,6 @@
 package breeze.util
 
 import org.slf4j.LoggerFactory
-import com.typesafe.scalalogging.slf4j.Logger
-
 
 /**
  * Stupid Typesafe logging lib trait isn't serializable. This is just a better version.
@@ -11,15 +9,15 @@ import com.typesafe.scalalogging.slf4j.Logger
  **/
 trait SerializableLogging extends Serializable {
   @transient @volatile
-  private var _the_logger:Logger = null
+  private var _the_logger: LazyLogger = null
 
-  def logger: Logger = {
+  protected def logger: LazyLogger = {
     var logger = _the_logger
     if(logger eq null) {
       synchronized {
         logger = _the_logger
         if(logger eq null) {
-          val ll = Logger(LoggerFactory.getLogger(this.getClass))
+          val ll = new LazyLogger(LoggerFactory.getLogger(this.getClass))
           _the_logger = ll
           logger = ll
         }


### PR DESCRIPTION
@dlwh This PR remove scalalogging from breeze's dependencies. The main reason is that scalalogging is not backward compatible. No matter which version we use in breeze, it may conflict with other components of a project. What do you think?

Some related PRs in Spark:
1. https://github.com/apache/spark/pull/940
2. https://github.com/apache/spark/pull/1208
