### PR TITLE
Make gradient tester print a real percentage

### DIFF
--- a/math/src/main/scala/breeze/optimize/GradientTester.scala
+++ b/math/src/main/scala/breeze/optimize/GradientTester.scala
@@ -76,7 +76,7 @@ object GradientTester extends LazyLogging {
         tried += 1
       }
       if (tried % 100 == 0 || tried == sz) {
-        logger.info(f"Checked $tried of ${sz} (out of dimension ${x.size}). ${ok * 1.0 / tried}%.4g%% ok.")
+        logger.info(f"Checked $tried of ${sz} (out of dimension ${x.size}). ${ok * 100.0 / tried}%.4g%% ok.")
       }
     }
     differences


### PR DESCRIPTION
If all dimensions tested are correct, GradientTester currently reports "1.000% ok". Under English number format conventions this should be "100.0%".