### PR TITLE
SVD that returns left and right vectors with reduced sizes

### DIFF
--- a/math/src/main/scala/breeze/linalg/functions/svd.scala
+++ b/math/src/main/scala/breeze/linalg/functions/svd.scala
@@ -9,6 +9,11 @@ import breeze.linalg.operators.OpMulMatrix
 import breeze.linalg.support.CanTranspose
 
 
+//  Options fot the singular value decomposition (SVD) of a real M-by-N matrix
+sealed trait SVDMode
+case object CompleteSVD extends SVDMode  // all M columns of U and all N rows of V**T are returned in the arrays U and VT
+case object ReducedSVD extends SVDMode   // the first min(M,N) columns of U and the first min(M,N) rows of V**T are returned in the arrays U and VT
+
 
 /**
   * Computes the SVD of a m by n matrix
@@ -31,76 +36,143 @@ object svd extends UFunc {
   // implementations
 
   implicit object Svd_DM_Impl extends Impl[DenseMatrix[Double], DenseSVD] {
-    def apply(mat: DenseMatrix[Double]): DenseSVD = {
-      requireNonEmptyMatrix(mat)
-
-      val m = mat.rows
-      val n = mat.cols
-      val S = DenseVector.zeros[Double](m min n)
-      val U = DenseMatrix.zeros[Double](m,m)
-      val Vt = DenseMatrix.zeros[Double](n,n)
-      val iwork = new Array[Int](8 * (m min n) )
-      val workSize = ( 3
-        * scala.math.min(m, n)
-        * scala.math.min(m, n)
-        + scala.math.max(scala.math.max(m, n), 4 * scala.math.min(m, n)
-          * scala.math.min(m, n) + 4 * scala.math.min(m, n))
-      )
-      val work = new Array[Double](workSize)
-      val info = new intW(0)
-      val cm = copy(mat)
-
-      lapack.dgesdd(
-        "A", m, n,
-        cm.data, scala.math.max(1,m),
-        S.data, U.data, scala.math.max(1,m),
-        Vt.data, scala.math.max(1,n),
-        work,work.length,iwork, info)
-
-      if (info.`val` > 0)
-        throw new NotConvergedException(NotConvergedException.Iterations)
-      else if (info.`val` < 0)
-        throw new IllegalArgumentException()
-
-      SVD(U,S,Vt)
-    }
+    def apply(mat: DenseMatrix[Double]): DenseSVD = svd_double(mat)(mode = CompleteSVD)
   }
 
 
   implicit object Svd_DM_Impl_Float extends Impl[DenseMatrix[Float], SDenseSVD] {
-    def apply(mat: DenseMatrix[Float]): SDenseSVD = {
-      requireNonEmptyMatrix(mat)
+    def apply(mat: DenseMatrix[Float]): SDenseSVD = svd_float(mat)(mode = CompleteSVD)
+  }
 
-      val m = mat.rows
-      val n = mat.cols
-      val S = DenseVector.zeros[Float](m min n)
-      val U = DenseMatrix.zeros[Float](m,m)
-      val Vt = DenseMatrix.zeros[Float](n,n)
-      val iwork = new Array[Int](8 * (m min n) )
-      val workSize = ( 3
-        * scala.math.min(m, n)
-        * scala.math.min(m, n)
-        + scala.math.max(scala.math.max(m, n), 4 * scala.math.min(m, n)
-        * scala.math.min(m, n) + 4 * scala.math.min(m, n))
-        )
-      val work = new Array[Float](workSize)
-      val info = new intW(0)
-      val cm = copy(mat)
 
-      lapack.sgesdd(
-        "A", m, n,
-        cm.data, scala.math.max(1,m),
-        S.data, U.data, scala.math.max(1,m),
-        Vt.data, scala.math.max(1,n),
-        work,work.length,iwork, info)
-
-      if (info.`val` > 0)
-        throw new NotConvergedException(NotConvergedException.Iterations)
-      else if (info.`val` < 0)
-        throw new IllegalArgumentException()
-
-      SVD(U,S,Vt)
+  /**
+   * Option for computing part of the matrix U:
+   *       The first min(M,N) columns of U and the first min(M,N)
+   *       rows of V**T are returned in the arrays U and VT;
+   */
+  object reduced extends UFunc {
+    implicit object reduce_Svd_DM_Impl extends Impl[DenseMatrix[Double], DenseSVD] {
+      def apply(mat: DenseMatrix[Double]): DenseSVD = svd_double(mat)(mode = ReducedSVD)
     }
+
+    implicit object reduced_Svd_DM_Impl_Float extends Impl[DenseMatrix[Float], SDenseSVD] {
+      def apply(mat: DenseMatrix[Float]): SDenseSVD = svd_float(mat)(mode = ReducedSVD)
+    }
+  }
+
+  private def svd_double(mat: DenseMatrix[Double])(mode: SVDMode): DenseSVD = {
+    mode match {
+      case CompleteSVD => doSVD_Double(mat)(JOBZ = "A")
+      case ReducedSVD => doSVD_Double(mat)(JOBZ = "S")
+    }
+  }
+
+  private def svd_float(mat: DenseMatrix[Float])(mode: SVDMode): SDenseSVD = {
+    mode match {
+      case CompleteSVD => doSVD_Float(mat)(JOBZ = "A")
+      case ReducedSVD => doSVD_Float(mat)(JOBZ = "S")
+    }
+  }
+
+  /**
+   * Computes the singular value decomposition (SVD) of a real M-by-N matrix
+   *
+   * @param mat Real M-by-N matrix (DOUBLE PRECISION)
+   * @param JOBZ = 'A':  all M columns of U and all N rows of V**T are
+   *               returned in the arrays U and VT;
+   *             = 'S':  the first min(M,N) columns of U and the first
+   *               min(M,N) rows of V**T are returned in the arrays U
+   *               and VT;
+   * @return The singular value decomposition (SVD) with the singular values,
+   *         the left and right singular vectors (DOUBLE PRECISION)
+   */
+  private def doSVD_Double(mat: DenseMatrix[Double])(JOBZ: String): DenseSVD = {
+    requireNonEmptyMatrix(mat)
+
+    val m = mat.rows
+    val n = mat.cols
+    val S = DenseVector.zeros[Double](m min n)
+    val U = if (JOBZ == "A") DenseMatrix.zeros[Double](m,m)
+            else             DenseMatrix.zeros[Double](m,m min n)
+    val Vt = if (JOBZ == "A") DenseMatrix.zeros[Double](n,n)
+             else             DenseMatrix.zeros[Double](m min n,n)
+    val iwork = new Array[Int](8 * (m min n) )
+    val workSize = ( 3
+      * scala.math.min(m, n)
+      * scala.math.min(m, n)
+      + scala.math.max(scala.math.max(m, n), 4 * scala.math.min(m, n)
+      * scala.math.min(m, n) + 4 * scala.math.min(m, n))
+      )
+    val work = new Array[Double](workSize)
+    val info = new intW(0)
+    val cm = copy(mat)
+
+    val LDVT = if (JOBZ == "A") scala.math.max(1,n)
+               else             m min n
+
+    lapack.dgesdd(
+      JOBZ, m, n,
+      cm.data, scala.math.max(1,m),
+      S.data, U.data, scala.math.max(1,m),
+      Vt.data, LDVT,
+      work,work.length,iwork, info)
+
+    if (info.`val` > 0)
+      throw new NotConvergedException(NotConvergedException.Iterations)
+    else if (info.`val` < 0)
+      throw new IllegalArgumentException()
+
+    SVD(U,S,Vt)
+  }
+
+  /**
+   * Computes the singular value decomposition (SVD) of a real M-by-N matrix
+   * @param mat Real M-by-N matrix (SINGLE PRECISION)
+   * @param JOBZ = 'A':  all M columns of U and all N rows of V**T are
+   *               returned in the arrays U and VT;
+   *             = 'S':  the first min(M,N) columns of U and the first
+   *               min(M,N) rows of V**T are returned in the arrays U
+   *               and VT;
+   * @return The singular value decomposition (SVD) with the singular values,
+   *         the left and right singular vectors (SINGLE PRECISION)
+   */
+  private def doSVD_Float(mat: DenseMatrix[Float])(JOBZ: String): SDenseSVD = {
+    requireNonEmptyMatrix(mat)
+
+    val m = mat.rows
+    val n = mat.cols
+    val S = DenseVector.zeros[Float](m min n)
+    val U = if (JOBZ == "A") DenseMatrix.zeros[Float](m,m)
+            else             DenseMatrix.zeros[Float](m,m min n)
+    val Vt = if (JOBZ == "A") DenseMatrix.zeros[Float](n,n)
+             else             DenseMatrix.zeros[Float](m min n,n)
+    val iwork = new Array[Int](8 * (m min n) )
+    val workSize = ( 3
+      * scala.math.min(m, n)
+      * scala.math.min(m, n)
+      + scala.math.max(scala.math.max(m, n), 4 * scala.math.min(m, n)
+      * scala.math.min(m, n) + 4 * scala.math.min(m, n))
+      )
+    val work = new Array[Float](workSize)
+    val info = new intW(0)
+    val cm = copy(mat)
+
+    val LDVT = if (JOBZ == "A") scala.math.max(1,n)
+               else             m min n
+
+    lapack.sgesdd(
+      JOBZ, m, n,
+      cm.data, scala.math.max(1,m),
+      S.data, U.data, scala.math.max(1,m),
+      Vt.data, LDVT,
+      work,work.length,iwork, info)
+
+    if (info.`val` > 0)
+      throw new NotConvergedException(NotConvergedException.Iterations)
+    else if (info.`val` < 0)
+      throw new IllegalArgumentException()
+
+    SVD(U,S,Vt)
   }
 
   type OpMulMatrixDenseVector[Mat] = OpMulMatrix.Impl2[Mat, DenseVector[Double], DenseVector[Double]]

--- a/math/src/main/scala/breeze/linalg/functions/svd.scala
+++ b/math/src/main/scala/breeze/linalg/functions/svd.scala
@@ -16,8 +16,8 @@ case object ReducedSVD extends SVDMode("S")   // the first min(M,N) columns of U
 
 
 /**
-  * Computes the SVD of a m by n matrix
-  * Returns an m*m matrix U, a vector of singular values, and a n*n matrix V'
+  * Computes the SVD of a M-by-N matrix
+  * Returns an M-by-M matrix U, a vector of singular values, and a N-by-N matrix V'
   */
 object svd extends UFunc {
 
@@ -46,12 +46,12 @@ object svd extends UFunc {
 
 
   /**
-   * Option for computing part of the matrix U:
+   * Option for computing part of the M-by-N matrix U:
    *       The first min(M,N) columns of U and the first min(M,N)
    *       rows of V**T are returned in the arrays U and VT;
    */
   object reduced extends UFunc {
-    implicit object reduce_Svd_DM_Impl extends Impl[DenseMatrix[Double], DenseSVD] {
+    implicit object reduced_Svd_DM_Impl extends Impl[DenseMatrix[Double], DenseSVD] {
       def apply(mat: DenseMatrix[Double]): DenseSVD = doSVD_Double(mat)(mode = ReducedSVD)
     }
 

--- a/math/src/test/scala/breeze/linalg/LinearAlgebraTest.scala
+++ b/math/src/test/scala/breeze/linalg/LinearAlgebraTest.scala
@@ -315,7 +315,7 @@ class LinearAlgebraTest extends FunSuite with Checkers with Matchers with Double
     // TODO, we seem to throw out VI... these seems bad...
   }
 
-  test("svd") {
+  test("svd A(m, n), m > n") {
     val m = DenseMatrix((2.0,4.0),(1.0,3.0),(0.0,0.0),(0.0,0.0))
     val SVD(u, s, vt) = svd(m)
 
@@ -334,6 +334,205 @@ class LinearAlgebraTest extends FunSuite with Checkers with Matchers with Double
     diag(ss(0 until s.length, 0 until s.length)) := s
     val reM: DenseMatrix[Double] =  u * ss * vt
     matricesNearlyEqual(reM, m)
+  }
+
+  test("svd A(m, n), m < n") {
+    val m = DenseMatrix((2.0,4.0),(1.0,3.0),(0.0,0.0),(0.0,0.0)).t
+    val SVD(u, s, vt) = svd(m)
+
+    // u and vt are unitary
+    trace(u.t * u) should be (u.rows.toDouble +- 1E-5)
+    trace(vt * vt.t) should be (vt.rows.toDouble +- 1E-5)
+
+    // s is sorted by size of singular value, and be nonnegative
+    for(i <- 1 until s.length) {
+      assert(s(i) <= s(i-1), s"s($i) > s(${i-1}): ${s(i)} > ${s(i-1)}")
+      assert(s(i) >= 0, s"s($i) < 0: ${s(i)}")
+    }
+
+
+    val ss = DenseMatrix.zeros[Double](m.rows, m.cols)
+    diag(ss(0 until s.length, 0 until s.length)) := s
+    val reM: DenseMatrix[Double] =  u * ss * vt
+    matricesNearlyEqual(reM, m)
+  }
+
+  test("svd float A(m, n), m > n") {
+    val m: DenseMatrix[Float] = DenseMatrix((2.0f,4.0f),(1.0f,3.0f),(0.0f,0.0f),(0.0f,0.0f))
+    val SVD(u, s, vt) = svd(m)
+
+    // u and vt are unitary
+    trace(u.t * u) should be (u.rows.toFloat +- 1E-5f)
+    trace(vt * vt.t) should be (vt.rows.toFloat +- 1E-5f)
+
+    // s is sorted by size of singular value, and be nonnegative
+    for(i <- 1 until s.length) {
+      assert(s(i) <= s(i-1), s"s($i) > s(${i-1}): ${s(i)} > ${s(i-1)}")
+      assert(s(i) >= 0, s"s($i) < 0: ${s(i)}")
+    }
+
+
+    val ss = DenseMatrix.zeros[Float](m.rows, m.cols)
+    diag(ss(0 until s.length, 0 until s.length)) := s
+    val reM: DenseMatrix[Float] =  u * ss * vt
+    // matricesNearlyEqual(reM, m)
+    for(i <- 0 until reM.rows; j <- 0 until reM.cols)
+      reM(i,j) should be (m(i, j) +- 1E-6f)
+  }
+
+  test("svd float A(m, n), m < n") {
+    val m: DenseMatrix[Float] = DenseMatrix((2.0f,4.0f),(1.0f,3.0f),(0.0f,0.0f),(0.0f,0.0f)).t
+    val SVD(u, s, vt) = svd(m)
+
+    // u and vt are unitary
+    trace(u.t * u) should be (u.rows.toFloat +- 1E-5f)
+    trace(vt * vt.t) should be (vt.rows.toFloat +- 1E-5f)
+
+    // s is sorted by size of singular value, and be nonnegative
+    for(i <- 1 until s.length) {
+      assert(s(i) <= s(i-1), s"s($i) > s(${i-1}): ${s(i)} > ${s(i-1)}")
+      assert(s(i) >= 0, s"s($i) < 0: ${s(i)}")
+    }
+
+
+    val ss = DenseMatrix.zeros[Float](m.rows, m.cols)
+    diag(ss(0 until s.length, 0 until s.length)) := s
+    val reM: DenseMatrix[Float] =  u * ss * vt
+    // matricesNearlyEqual(reM, m)
+    for(i <- 0 until reM.rows; j <- 0 until reM.cols)
+      reM(i,j) should be (m(i, j) +- 1E-5f)
+  }
+
+  test("svd reduced A(m, n), m > n") {
+    val m = DenseMatrix((2.0,4.0),(1.0,3.0),(0.0,0.0),(0.0,0.0))
+    val SVD(u, s, vt) = svd.reduced(m)
+
+    // u and vt are unitary
+    trace(u.t * u) should be (u.cols.toDouble +- 1E-5)
+    trace(vt * vt.t) should be (vt.rows.toDouble +- 1E-5)
+
+    // s is sorted by size of singular value, and be nonnegative
+    for(i <- 1 until s.length) {
+      assert(s(i) <= s(i-1), s"s($i) > s(${i-1}): ${s(i)} > ${s(i-1)}")
+      assert(s(i) >= 0, s"s($i) < 0: ${s(i)}")
+    }
+
+
+    val ss = DenseMatrix.zeros[Double](m.rows min m.cols, m.rows min m.cols)
+    diag(ss(0 until s.length, 0 until s.length)) := s
+    val reM: DenseMatrix[Double] =  u * ss * vt
+    matricesNearlyEqual(reM, m)
+  }
+
+  test("svd reduced A(m, n), m < n") {
+    val m = DenseMatrix((2.0,4.0),(1.0,3.0),(0.0,0.0),(0.0,0.0)).t
+    val SVD(u, s, vt) = svd.reduced(m)
+
+    // u and vt are unitary
+    trace(u.t * u) should be (u.cols.toDouble +- 1E-5)
+    trace(vt * vt.t) should be (vt.rows.toDouble +- 1E-5)
+
+    // s is sorted by size of singular value, and be nonnegative
+    for(i <- 1 until s.length) {
+      assert(s(i) <= s(i-1), s"s($i) > s(${i-1}): ${s(i)} > ${s(i-1)}")
+      assert(s(i) >= 0, s"s($i) < 0: ${s(i)}")
+    }
+
+
+    val ss = DenseMatrix.zeros[Double](m.rows min m.cols, m.rows min m.cols)
+    diag(ss(0 until s.length, 0 until s.length)) := s
+    val reM: DenseMatrix[Double] =  u * ss * vt
+    matricesNearlyEqual(reM, m)
+  }
+
+  test("svd reduced A(m, n), m = n") {
+    val m = DenseMatrix((2.0,4.0),(1.0,3.0))
+    val SVD(u, s, vt) = svd.reduced(m)
+
+    // u and vt are unitary
+    trace(u.t * u) should be (u.cols.toDouble +- 1E-5)
+    trace(vt * vt.t) should be (vt.rows.toDouble +- 1E-5)
+
+    // s is sorted by size of singular value, and be nonnegative
+    for(i <- 1 until s.length) {
+      assert(s(i) <= s(i-1), s"s($i) > s(${i-1}): ${s(i)} > ${s(i-1)}")
+      assert(s(i) >= 0, s"s($i) < 0: ${s(i)}")
+    }
+
+
+    val ss = DenseMatrix.zeros[Double](m.rows min m.cols, m.rows min m.cols)
+    diag(ss(0 until s.length, 0 until s.length)) := s
+    val reM: DenseMatrix[Double] =  u * ss * vt
+    matricesNearlyEqual(reM, m)
+  }
+
+  test("svd reduced float A(m, n), m > n") {
+    val m = DenseMatrix((2.0f,4.0f),(1.0f,3.0f),(0.0f,0.0f),(0.0f,0.0f))
+    val SVD(u, s, vt) = svd.reduced(m)
+
+    // u and vt are unitary
+    trace(u.t * u) should be (u.cols.toFloat +- 1E-5f)
+    trace(vt * vt.t) should be (vt.rows.toFloat +- 1E-5f)
+
+    // s is sorted by size of singular value, and be nonnegative
+    for(i <- 1 until s.length) {
+      assert(s(i) <= s(i-1), s"s($i) > s(${i-1}): ${s(i)} > ${s(i-1)}")
+      assert(s(i) >= 0, s"s($i) < 0: ${s(i)}")
+    }
+
+
+    val ss = DenseMatrix.zeros[Float](m.rows min m.cols, m.rows min m.cols)
+    diag(ss(0 until s.length, 0 until s.length)) := s
+    val reM: DenseMatrix[Float] =  u * ss * vt
+    // matricesNearlyEqual(reM, m)
+    for(i <- 0 until reM.rows; j <- 0 until reM.cols)
+      reM(i,j) should be (m(i, j) +- 1E-6f)
+  }
+
+  test("svd reduced float A(m, n), m = n") {
+    val m = DenseMatrix((2.0f,4.0f),(1.0f,3.0f))
+    val SVD(u, s, vt) = svd.reduced(m)
+
+    // u and vt are unitary
+    trace(u.t * u) should be (u.cols.toFloat +- 1E-5f)
+    trace(vt * vt.t) should be (vt.rows.toFloat +- 1E-5f)
+
+    // s is sorted by size of singular value, and be nonnegative
+    for(i <- 1 until s.length) {
+      assert(s(i) <= s(i-1), s"s($i) > s(${i-1}): ${s(i)} > ${s(i-1)}")
+      assert(s(i) >= 0, s"s($i) < 0: ${s(i)}")
+    }
+
+
+    val ss = DenseMatrix.zeros[Float](m.rows min m.cols, m.rows min m.cols)
+    diag(ss(0 until s.length, 0 until s.length)) := s
+    val reM: DenseMatrix[Float] =  u * ss * vt
+    // matricesNearlyEqual(reM, m)
+    for(i <- 0 until reM.rows; j <- 0 until reM.cols)
+      reM(i,j) should be (m(i, j) +- 1E-5f)
+  }
+
+  test("svd reduced float A(m, n), m < n") {
+    val m = DenseMatrix((2.0f,4.0f),(1.0f,3.0f),(0.0f,0.0f),(0.0f,0.0f)).t
+    val SVD(u, s, vt) = svd.reduced(m)
+
+    // u and vt are unitary
+    trace(u.t * u) should be (u.cols.toFloat +- 1E-5f)
+    trace(vt * vt.t) should be (vt.rows.toFloat +- 1E-5f)
+
+    // s is sorted by size of singular value, and be nonnegative
+    for(i <- 1 until s.length) {
+      assert(s(i) <= s(i-1), s"s($i) > s(${i-1}): ${s(i)} > ${s(i-1)}")
+      assert(s(i) >= 0, s"s($i) < 0: ${s(i)}")
+    }
+
+
+    val ss = DenseMatrix.zeros[Float](m.rows min m.cols, m.rows min m.cols)
+    diag(ss(0 until s.length, 0 until s.length)) := s
+    val reM: DenseMatrix[Float] =  u * ss * vt
+    // matricesNearlyEqual(reM, m)
+    for(i <- 0 until reM.rows; j <- 0 until reM.cols)
+      reM(i,j) should be (m(i, j) +- 1E-5f)
   }
 
   test("csc svd"){


### PR DESCRIPTION
Reduced mode for SVD of real matrix A(M, N) that allows to return U and V.t with dimensions (M, K) and (K, N) with K = min(M, N) correspondently.

Example of use:

```scala
val m = DenseMatrix((2.0,4.0),(1.0,3.0),(0.0,0.0),(0.0,0.0))
val SVD(u, s, vt) = svd.reduced(m)
```

Refer to issue #303