### PR TITLE
Tile UFunc

### DIFF
--- a/math/src/main/scala/breeze/linalg/functions/tile.scala
+++ b/math/src/main/scala/breeze/linalg/functions/tile.scala
@@ -15,8 +15,7 @@ object tile extends UFunc {
   implicit def tile_DV_Impl2[T:ClassTag:Semiring:Zero]: Impl2[DenseVector[T], Int, DenseVector[T]] = {
     new Impl2[DenseVector[T],Int,DenseVector[T]] {
       def apply(x:DenseVector[T], n:Int):DenseVector[T] = {
-        // Note: DenseVector is column-major, i.e., it can be considered a matrix of size (v.length x 1)
-//        var out = new ArrayBuffer[T]()
+        // DenseVector is column-major, i.e., it can be considered a matrix of size (v.length x 1)
         val out = new DenseVector[T](x.length * n)
         var i = 0
         while(i < n) {
@@ -32,7 +31,7 @@ object tile extends UFunc {
   Impl3[DenseVector[T], Int, Int, DenseMatrix[T]] =
     new Impl3[DenseVector[T],Int, Int, DenseMatrix[T]] {
       def apply(x: DenseVector[T], m: Int, n: Int): DenseMatrix[T] = {
-        // Note: DenseVector is column-major, i.e., it can be considered a matrix of size (v.length x 1)
+        // DenseVector is column-major, i.e., it can be considered a matrix of size (v.length x 1)
         // So, first construct the tiled column.
         val col = impl2(x, m)
         // Now, replicate the col.

--- a/math/src/main/scala/breeze/linalg/functions/tile.scala
+++ b/math/src/main/scala/breeze/linalg/functions/tile.scala
@@ -1,0 +1,84 @@
+package breeze.linalg
+
+import breeze.generic.UFunc
+import breeze.math.Semiring
+import breeze.storage.Zero
+import scala.reflect.ClassTag
+
+/**
+ * @author Rakesh Chalasani <vnit.rakesh@gmail.com>
+ */
+object tile extends UFunc {
+
+  // implementations
+
+  implicit def tile_DV_Impl2[T:ClassTag:Semiring:Zero]: Impl2[DenseVector[T], Int, DenseVector[T]] = {
+    new Impl2[DenseVector[T],Int,DenseVector[T]] {
+      def apply(x:DenseVector[T], n:Int):DenseVector[T] = {
+        // Note: DenseVector is column-major, i.e., it can be considered a matrix of size (v.length x 1)
+//        var out = new ArrayBuffer[T]()
+        val out = new DenseVector[T](x.length * n)
+        var i = 0
+        while(i < n) {
+          out(i*x.length until (i+1)*x.length) := x
+          i += 1
+        }
+        out
+      }
+    }
+  }
+
+  implicit def tile_DV_Impl3[T:ClassTag:Semiring:Zero](implicit impl2: Impl2[DenseVector[T], Int, DenseVector[T]]):
+  Impl3[DenseVector[T], Int, Int, DenseMatrix[T]] =
+    new Impl3[DenseVector[T],Int, Int, DenseMatrix[T]] {
+      def apply(x: DenseVector[T], m: Int, n: Int): DenseMatrix[T] = {
+        // Note: DenseVector is column-major, i.e., it can be considered a matrix of size (v.length x 1)
+        // So, first construct the tiled column.
+        val col = impl2(x, m)
+        // Now, replicate the col.
+        val out = new DenseMatrix[T](x.length * m, n)
+        var i = 0
+        while (i < n) {
+          out(::,i) := col
+          i += 1
+        }
+        out
+      }
+    }
+
+  implicit def tile_DM_Impl2[T:ClassTag:Semiring:Zero]: Impl2[DenseMatrix[T], Int, DenseMatrix[T]] =
+    new Impl2[DenseMatrix[T], Int, DenseMatrix[T]] {
+      def apply(x: DenseMatrix[T], m: Int):DenseMatrix[T] = {
+        // Replicate each column 'm' times.
+        val out = new DenseMatrix[T](x.rows * m, x.cols)
+        var i = 0
+        while(i < x.cols) {
+          val column = x(::, i)
+          var j = 0
+          while(j < m) {
+            out(j*x.rows until (j+1)*x.rows, i) := column
+            j += 1
+          }
+          i += 1
+        }
+        out
+      }
+    }
+
+  implicit def tile_DM_Impl3[T:ClassTag:Semiring:Zero](implicit impl2:Impl2[DenseMatrix[T],Int, DenseMatrix[T]]):
+    Impl3[DenseMatrix[T], Int, Int, DenseMatrix[T]] =
+    new Impl3[DenseMatrix[T], Int, Int, DenseMatrix[T]] {
+      def apply(x: DenseMatrix[T], m: Int, n:Int):DenseMatrix[T] = {
+        // First, replicate each column 'm' times.
+        val columnTiledMatrix = impl2(x,m)
+        // Nom, replicate the columnTiledMatrix 'n' times.
+        val out = new DenseMatrix[T](x.rows * m, x.cols * n)
+        var i = 0
+        while(i < n) {
+          out(::,i*x.cols until (i+1)*x.cols) := columnTiledMatrix
+          i += 1
+        }
+        out
+      }
+    }
+}

--- a/math/src/test/scala/breeze/linalg/functions/tileTest.scala
+++ b/math/src/test/scala/breeze/linalg/functions/tileTest.scala
@@ -1,0 +1,36 @@
+package breeze.linalg.functions
+
+import breeze.linalg.{DenseVector, tile, DenseMatrix}
+import org.scalatest.FunSuite
+
+/**
+ * 2/21/15.
+ * @author Rakesh Chalasani
+ */
+class tileTest extends FunSuite {
+  test("tile ( DenseMatrix , Int)") {
+    val m = new DenseMatrix(2,2, Array.range(0, 4))
+    assert(tile(m,2) == new DenseMatrix[Int](4,2, Array(0,1,0,1,2,3,2,3)))
+  }
+
+  test("tile ( DenseMatrix , Int, Int)") {
+    val m = new DenseMatrix(2,2, Array.range(0, 4))
+    assert(tile(m,2,2) == new DenseMatrix[Int](4,4, Array(0,1,0,1,2,3,2,3,0,1,0,1,2,3,2,3)))
+  }
+
+  test("tile ( DenseMatrix , Int, Int) non-square matrix.") {
+    val m = new DenseMatrix(1,2, Array.range(0, 2))
+    assert(tile(m,2,3) == new DenseMatrix[Int](2,6, Array(0,0,1,1,0,0,1,1,0,0,1,1)))
+  }
+
+  test("tile (DenseVector, Int) ") {
+    val v = DenseVector(1,2,3,4)
+    assert(tile(v,2) == DenseVector[Int](1,2,3,4,1,2,3,4))
+  }
+
+  test("tile (DenseVector, Int, Int) ") {
+    val v = DenseVector(1,2,3,4)
+    assert(tile(v,2, 3) == new DenseMatrix[Int](8,3,
+      Array(1,2,3,4,1,2,3,4,1,2,3,4,1,2,3,4,1,2,3,4,1,2,3,4)))
+  }
+}


### PR DESCRIPTION
Similar to numpy tile
http://docs.scipy.org/doc/numpy/reference/generated/numpy.tile.html

Only implemented for DenseVector and DenseMatrix.
Ex: 
```
tile(DenseVector(1,2),2)  // Creates DenseVector of length 4
tile(DenseVector(1,2),2,2) // Creates (4 x 2) DenseMatrix
tile(DenseMatrix.rand[Double](2,2), 2,3) // Creates (4 x 6) DenseMatrix
```