### PR TITLE
expose improvementTol inside FirstOrderMinimizer

### DIFF
--- a/math/src/main/scala/breeze/optimize/LBFGS.scala
+++ b/math/src/main/scala/breeze/optimize/LBFGS.scala
@@ -38,7 +38,7 @@ import breeze.util.SerializableLogging
  * @param m: The memory of the search. 3 to 7 is usually sufficient.
  */
 class LBFGS[T](maxIter: Int = -1, m: Int=10, tolerance: Double=1E-9)
-              (implicit space: MutableInnerProductModule[T, Double]) extends FirstOrderMinimizer[T, DiffFunction[T]](maxIter, tolerance) with SerializableLogging {
+              (implicit space: MutableInnerProductModule[T, Double]) extends FirstOrderMinimizer[T, DiffFunction[T]](maxIter, tolerance, tolerance) with SerializableLogging {
 
   import space._
   require(m > 0)


### PR DESCRIPTION
When I run the LBFGS implementation of Spark on a moderate size proprietary data set (~ 5M samples), I see the resultant vector diverges from some standard solver (e.g., liblinear, sci-learn) on around half of the coefficients. The computation usually stops around 20 iterations although I set the iteration number to be 100 with a very strict tolerance variable (1e-15). The formulation is strongly convex so the solution should be unique. Configing the `improvementTol` variable inside `FirstOrderMinimizer.scala` can solve this issue.

Two ways of doing this:
1. Exposing the `improvementTol` variable to LBFGS, as is done in the PR
2. Change the default value of `improvementTol` in `FirstOrderMinimizer.scala`

I chose the first one here.