### PR TITLE
Make NNLS serializable

### DIFF
--- a/math/src/main/scala/breeze/optimize/linear/NNLS.scala
+++ b/math/src/main/scala/breeze/optimize/linear/NNLS.scala
@@ -4,6 +4,7 @@ import breeze.linalg.{DenseMatrix, DenseVector, axpy}
 import breeze.optimize.proximal.QpGenerator
 import breeze.stats.distributions.Rand
 import breeze.util.Implicits._
+import breeze.util.SerializableLogging
 import spire.syntax.cfor._
 
 /**
@@ -13,7 +14,7 @@ import spire.syntax.cfor._
  * @author debasish83, coderxiang
  */
 
-class NNLS(val maxIters: Int = -1) {
+class NNLS(val maxIters: Int = -1) extends SerializableLogging {
   type BDM = DenseMatrix[Double]
   type BDV = DenseVector[Double]
 


### PR DESCRIPTION
NNLS was not serializable which causes Spark integration to fail. 

QuadraticMinimizer integrated fine with Spark. 