### PR TITLE
QuadraticMinimizer.updateGram cleaned exceptions

### DIFF
--- a/math/src/main/scala/breeze/optimize/proximal/QuadraticMinimizer.scala
+++ b/math/src/main/scala/breeze/optimize/proximal/QuadraticMinimizer.scala
@@ -112,6 +112,8 @@ class QuadraticMinimizer(nGram: Int,
    * of update. No exceptions are thrown explicitly to optimize on the runtime
    */
   def updateGram(row: Int, col: Int, value: Double) {
+    require(row >= 0 && row < n, s"QuadraticMinimizer:updateGram row index out of bounds")
+    require(col >= 0 && col < n, s"QuadraticMinimizer:updateGram col index out of bounds")
     wsH.update(row, col, value)
   }
 

--- a/math/src/main/scala/breeze/optimize/proximal/QuadraticMinimizer.scala
+++ b/math/src/main/scala/breeze/optimize/proximal/QuadraticMinimizer.scala
@@ -107,11 +107,11 @@ class QuadraticMinimizer(nGram: Int,
 
   def getProximal = proximal
 
+  /**
+   * updateGram API is meant to be called iteratively from the user and the user should guarantee correctness
+   * of update. No exceptions are thrown explicitly to optimize on the runtime
+   */
   def updateGram(row: Int, col: Int, value: Double) {
-    if (row < 0 || row >= n)
-      throw new IllegalArgumentException("QuadraticMinimizer row out of bounds for gram matrix update")
-    if (col < 0 || col >= n)
-      throw new IllegalArgumentException("QuadraticMinimizer column out of bounds for gram matrix update")
     wsH.update(row, col, value)
   }
 


### PR DESCRIPTION
At each iteration of updateGram I was checking if the indices are within bounds but when we call it from mllib ALS, we make sure upfront if the indices are fine. Having conditional checks will affect the performance for example. I cleaned it up and added a comment so that users are aware of this optimization.