### PR TITLE
Index range tests in SparseVector are off by one.

### DIFF
--- a/math/src/main/scala/breeze/linalg/SparseVector.scala
+++ b/math/src/main/scala/breeze/linalg/SparseVector.scala
@@ -71,12 +71,12 @@ class SparseVector[@spec(Double, Int, Float, Long) V](val array: SparseArray[V])
   def contains(i: Int) = array.contains(i)
 
   def apply(i: Int): V = {
-    if(i < 0 || i > size) throw new IndexOutOfBoundsException(i + " not in [0,"+size+")")
+    if(i < 0 || i >= size) throw new IndexOutOfBoundsException(i + " not in [0,"+size+")")
     array(i)
   }
 
   def update(i: Int, v: V): Unit = {
-    if(i < 0 || i > size) throw new IndexOutOfBoundsException(i + " not in [0,"+size+")")
+    if(i < 0 || i >= size) throw new IndexOutOfBoundsException(i + " not in [0,"+size+")")
     array(i) = v
   }
 

--- a/math/src/main/scala/breeze/linalg/VectorBuilder.scala
+++ b/math/src/main/scala/breeze/linalg/VectorBuilder.scala
@@ -69,7 +69,7 @@ class VectorBuilder[@spec(Double, Int, Float, Long) E](private var _index: Array
   def contains(i: Int) = _index.contains(i)
 
   def apply(i: Int) = {
-    if(i < 0 || i > size) throw new IndexOutOfBoundsException(i + " not in [0,"+size+")")
+    if(i < 0 || i >= size) throw new IndexOutOfBoundsException(i + " not in [0,"+size+")")
 
     var off = 0
     var acc = ring.zero
@@ -82,7 +82,7 @@ class VectorBuilder[@spec(Double, Int, Float, Long) E](private var _index: Array
   }
 
   def update(i: Int, v: E) {
-    if(i < 0 || i > size) throw new IndexOutOfBoundsException(i + " not in [0,"+size+")")
+    if(i < 0 || i >= size) throw new IndexOutOfBoundsException(i + " not in [0,"+size+")")
     var marked = false
     var off = 0
     while(off < used) {
@@ -98,7 +98,7 @@ class VectorBuilder[@spec(Double, Int, Float, Long) E](private var _index: Array
   }
 
   def add(i: Int, v: E) {
-    if(i < 0 || i > size) throw new IndexOutOfBoundsException(i + " not in [0,"+size+")")
+    if(i < 0 || i >= size) throw new IndexOutOfBoundsException(i + " not in [0,"+size+")")
 
     if(_data.length <= used) {
       _data = ArrayUtil.copyOf(_data, math.max(_data.length * 2, 1))


### PR DESCRIPTION
There are redundant range tests in SparseVector so the previous behavior was observably correct and had test coverage already. This fix ensures the failures happen at a consistent location.

Example call stack prior to the fix, note that the exception is thrown from `SparseArray.findOffset` and not `SparseVector.apply`:

    Exception in thread "main" java.lang.IndexOutOfBoundsException: Index 12 out of bounds [0,12)
        at breeze.collection.mutable.SparseArray.findOffset(SparseArray.scala:198)
        at breeze.collection.mutable.SparseArray.apply(SparseArray.scala:53)
        at breeze.collection.mutable.SparseArray.apply$mcD$sp(SparseArray.scala:52)
        at breeze.linalg.SparseVector$mcD$sp.apply$mcD$sp(SparseVector.scala:75)
        at breeze.linalg.SparseVector$mcD$sp.apply(SparseVector.scala:73)
        at breeze.linalg.SparseVector$mcD$sp.apply(SparseVector.scala:49)
        at breeze.linalg.TensorLike$class.apply$mcID$sp(Tensor.scala:94)
        at breeze.linalg.SparseVector.apply$mcID$sp(SparseVector.scala:49)