### PR TITLE
Convergence a la carte

### DIFF
--- a/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
+++ b/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
@@ -31,7 +31,7 @@ abstract class FirstOrderMinimizer[T, DF<:StochasticDiffFunction[T]](val converg
            minImprovementWindow: Int = 10,
            numberOfImprovementFailures: Int = 1,
            relativeTolerance: Boolean = true)(implicit space: NormedModule[T, Double]) =
-    this(FirstOrderMinimizer.defaultConvergenceCheck[T, FirstOrderMinimizer[T, DF]#History](maxIter, tolerance, relativeTolerance), improvementTol, minImprovementWindow, numberOfImprovementFailures)
+    this(FirstOrderMinimizer.defaultConvergenceCheck[T, FirstOrderMinimizer[T, DF]#History](maxIter, tolerance, relativeTolerance).lift, improvementTol, minImprovementWindow, numberOfImprovementFailures)
   import space.normImpl
 
 
@@ -191,14 +191,14 @@ object FirstOrderMinimizer {
     case s: State[_, _] if (s.searchFailed) =>
       SearchFailed
   }
-  def defaultConvergenceCheck[T, History](maxIter: Int, tolerance: Double, relative: Boolean = true)(implicit space: NormedModule[T, Double]): State[T, History] => Option[ConvergenceReason] =
+  def defaultConvergenceCheck[T, History](maxIter: Int, tolerance: Double, relative: Boolean = true)(implicit space: NormedModule[T, Double]): PartialFunction[State[T, History], ConvergenceReason] =
     (
       maxIterationsReached[T, History](maxIter) ||
       functionValuesConverged[T, History](tolerance, relative) ||
       objectiveNotImproving[T, History](tolerance, relative) ||
       gradientConverged[T, History](tolerance, relative) ||
       searchFailed[T, History]
-    ).lift
+    )
 
   /**
    * OptParams is a Configuration-compatible case class that can be used to select optimization

--- a/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
+++ b/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
@@ -149,7 +149,7 @@ object FirstOrderMinimizer {
     def ||(otherCheck: ConvergenceCheck[T, History]): ConvergenceCheck[T, History] = check orElse otherCheck
   }
 
-  sealed trait ConvergenceReason {
+  trait ConvergenceReason {
     def reason: String
   }
   case object MaxIterations extends ConvergenceReason {

--- a/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
+++ b/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
@@ -68,19 +68,19 @@ abstract class FirstOrderMinimizer[T, DF<:StochasticDiffFunction[T]](maxIter: In
     )
   }
 
-  val maxIterationsReached: ConvergenceCheck = {
+  def maxIterationsReached(maxIter: Int): ConvergenceCheck = {
     case s: State if (s.iter >= maxIter && maxIter >= 0) =>
       FirstOrderMinimizer.MaxIterations
   }
-  val functionValuesConverged: ConvergenceCheck = {
+  def functionValuesConverged(tolerance: Double): ConvergenceCheck = {
     case s: State if (!s.fVals.isEmpty && (s.adjustedValue - s.fVals.max).abs <= tolerance * s.initialAdjVal) =>
     FirstOrderMinimizer.FunctionValuesConverged
   }
-  val objectiveNotImproving: ConvergenceCheck = {
+  def objectiveNotImproving(tolerance: Double): ConvergenceCheck = {
     case s: State if (!s.fVals.isEmpty && (s.adjustedValue - s.fVals.max).abs <= tolerance * s.initialAdjVal) =>
       FirstOrderMinimizer.FunctionValuesConverged
   }
-  val gradientConverged: ConvergenceCheck = {
+  def gradientConverged(tolerance: Double): ConvergenceCheck = {
     case s: State if (norm(s.adjustedGradient) <= math.max(tolerance * s.adjustedValue.abs, 1E-8)) =>
       FirstOrderMinimizer.GradientConverged
   }
@@ -89,7 +89,7 @@ abstract class FirstOrderMinimizer[T, DF<:StochasticDiffFunction[T]](maxIter: In
       FirstOrderMinimizer.SearchFailed
   }
   val defaultConvergenceChecks: Seq[ConvergenceCheck] =
-    Seq(maxIterationsReached, functionValuesConverged, objectiveNotImproving, gradientConverged, searchFailed)
+    Seq(maxIterationsReached(maxIter), functionValuesConverged(tolerance), objectiveNotImproving(tolerance), gradientConverged(tolerance), searchFailed)
   protected def initialHistory(f: DF, init: T): History
   protected def adjustFunction(f: DF): DF = f
   protected def adjust(newX: T, newGrad: T, newVal: Double):(Double,T) = (newVal,newGrad)

--- a/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
+++ b/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
@@ -31,7 +31,7 @@ abstract class FirstOrderMinimizer[T, DF<:StochasticDiffFunction[T]](val converg
            minImprovementWindow: Int = 10,
            numberOfImprovementFailures: Int = 1,
            relativeTolerance: Boolean = true)(implicit space: NormedModule[T, Double]) =
-    this(FirstOrderMinimizer.createConvergenceCheck[T, FirstOrderMinimizer[T, DF]#History](maxIter, tolerance, relativeTolerance), improvementTol, minImprovementWindow, numberOfImprovementFailures)
+    this(FirstOrderMinimizer.defaultConvergenceCheck[T, FirstOrderMinimizer[T, DF]#History](maxIter, tolerance, relativeTolerance), improvementTol, minImprovementWindow, numberOfImprovementFailures)
   import space.normImpl
 
 
@@ -191,7 +191,7 @@ object FirstOrderMinimizer {
     case s: State[_, _] if (s.searchFailed) =>
       SearchFailed
   }
-  def createConvergenceCheck[T, History](maxIter: Int, tolerance: Double, relative: Boolean = true)(implicit space: NormedModule[T, Double]): State[T, History] => Option[ConvergenceReason] =
+  def defaultConvergenceCheck[T, History](maxIter: Int, tolerance: Double, relative: Boolean = true)(implicit space: NormedModule[T, Double]): State[T, History] => Option[ConvergenceReason] =
     (
       maxIterationsReached[T, History](maxIter) ||
       functionValuesConverged[T, History](tolerance, relative) ||

--- a/math/src/main/scala/breeze/optimize/ProjectedQuasiNewton.scala
+++ b/math/src/main/scala/breeze/optimize/ProjectedQuasiNewton.scala
@@ -91,31 +91,31 @@ class ProjectedQuasiNewton(convergenceCheck: FirstOrderMinimizer.State[DenseVect
   extends FirstOrderMinimizer[DenseVector[Double], DiffFunction[DenseVector[Double]]](convergenceCheck, 1E-3, 10, 1) with Projecting[DenseVector[Double]] with SerializableLogging {
   type BDV = DenseVector[Double]
   def this(tolerance: Double = 1e-6,
-  m: Int = 10,
-  initFeas: Boolean = false,
-  testOpt: Boolean = true,
-  maxIter: Int = -1,
-  maxSrchIt: Int = 50,
-  gamma: Double = 1e-4,
-  projection: DenseVector[Double] => DenseVector[Double] = identity,
-  relativeTolerance: Boolean = true)
-  (implicit space: MutableInnerProductModule[DenseVector[Double],Double]) = this(
-    convergenceCheck = FirstOrderMinimizer.defaultConvergenceCheck[DenseVector[Double], FirstOrderMinimizer[DenseVector[Double], DiffFunction[DenseVector[Double]]]#History](maxIter, tolerance, relativeTolerance).lift,
-    m = m,
-    initFeas = initFeas,
-    testOpt = testOpt,
-    maxSrchIt = maxSrchIt,
-    gamma = gamma,
-    projection = projection,
-    innerOptimizer = new SpectralProjectedGradient[DenseVector[Double]](
-      tolerance = tolerance,
-      maxIter = 50,
-      bbMemory = 5,
-      initFeas = true,
-      minImprovementWindow = 10,
-      projection = projection
+    m: Int = 10,
+    initFeas: Boolean = false,
+    testOpt: Boolean = true,
+    maxIter: Int = -1,
+    maxSrchIt: Int = 50,
+    gamma: Double = 1e-4,
+    projection: DenseVector[Double] => DenseVector[Double] = identity,
+    relativeTolerance: Boolean = true)
+    (implicit space: MutableInnerProductModule[DenseVector[Double],Double]) = this(
+      convergenceCheck = FirstOrderMinimizer.defaultConvergenceCheck[DenseVector[Double], FirstOrderMinimizer[DenseVector[Double], DiffFunction[DenseVector[Double]]]#History](maxIter, tolerance, relativeTolerance).lift,
+      m = m,
+      initFeas = initFeas,
+      testOpt = testOpt,
+      maxSrchIt = maxSrchIt,
+      gamma = gamma,
+      projection = projection,
+      innerOptimizer = new SpectralProjectedGradient[DenseVector[Double]](
+        tolerance = tolerance,
+        maxIter = 50,
+        bbMemory = 5,
+        initFeas = true,
+        minImprovementWindow = 10,
+        projection = projection
+      )
     )
-  )
 
   type History = CompactHessian
 

--- a/math/src/main/scala/breeze/optimize/ProjectedQuasiNewton.scala
+++ b/math/src/main/scala/breeze/optimize/ProjectedQuasiNewton.scala
@@ -100,7 +100,7 @@ class ProjectedQuasiNewton(convergenceCheck: FirstOrderMinimizer.State[DenseVect
   projection: DenseVector[Double] => DenseVector[Double] = identity,
   relativeTolerance: Boolean = true)
   (implicit space: MutableInnerProductModule[DenseVector[Double],Double]) = this(
-    convergenceCheck = FirstOrderMinimizer.defaultConvergenceCheck[DenseVector[Double], FirstOrderMinimizer[DenseVector[Double], DiffFunction[DenseVector[Double]]]#History](maxIter, tolerance, relativeTolerance),
+    convergenceCheck = FirstOrderMinimizer.defaultConvergenceCheck[DenseVector[Double], FirstOrderMinimizer[DenseVector[Double], DiffFunction[DenseVector[Double]]]#History](maxIter, tolerance, relativeTolerance).lift,
     m = m,
     initFeas = initFeas,
     testOpt = testOpt,

--- a/math/src/main/scala/breeze/optimize/ProjectedQuasiNewton.scala
+++ b/math/src/main/scala/breeze/optimize/ProjectedQuasiNewton.scala
@@ -19,6 +19,7 @@ package breeze.optimize
 import breeze.linalg._
 import breeze.collection.mutable.RingBuffer
 import breeze.math.MutableInnerProductModule
+import breeze.optimize.FirstOrderMinimizer.ConvergenceReason
 import breeze.util.SerializableLogging
 
 // Compact representation of an n x n Hessian, maintained via L-BFGS updates
@@ -78,25 +79,42 @@ class CompactHessian(M: DenseMatrix[Double], Y: RingBuffer[DenseVector[Double]],
   lazy val N = DenseMatrix.horzcat(collectionOfVectorsToMatrix(S).t * sigma, collectionOfVectorsToMatrix(Y).t)
 }
 
-class ProjectedQuasiNewton(tolerance: Double = 1e-6,
-                           val m: Int = 10,
-                           val initFeas: Boolean = false,
-                           val testOpt: Boolean = true,
-                           maxIter: Int = -1,
-                           val maxSrchIt: Int = 50,
-                           val gamma: Double = 1e-4,
-                           val projection: DenseVector[Double] => DenseVector[Double] = identity)
+class ProjectedQuasiNewton(convergenceCheck: FirstOrderMinimizer.State[DenseVector[Double], FirstOrderMinimizer[DenseVector[Double], DiffFunction[DenseVector[Double]]]#History] => Option[ConvergenceReason],
+                           val innerOptimizer: SpectralProjectedGradient[DenseVector[Double]],
+                           val m: Int,
+                           val initFeas: Boolean,
+                           val testOpt: Boolean,
+                           val maxSrchIt: Int,
+                           val gamma: Double,
+                           val projection: DenseVector[Double] => DenseVector[Double])
                           (implicit space: MutableInnerProductModule[DenseVector[Double],Double])
-  extends FirstOrderMinimizer[DenseVector[Double], DiffFunction[DenseVector[Double]]](maxIter = maxIter, tolerance = tolerance) with Projecting[DenseVector[Double]] with SerializableLogging {
+  extends FirstOrderMinimizer[DenseVector[Double], DiffFunction[DenseVector[Double]]](convergenceCheck, 1E-3, 10, 1) with Projecting[DenseVector[Double]] with SerializableLogging {
   type BDV = DenseVector[Double]
-
-  val innerOptimizer = new SpectralProjectedGradient[BDV](
-    tolerance = tolerance,
-    maxIter = 50,
-    bbMemory = 5,
-    initFeas = true,
-    minImprovementWindow = 10,
-    projection = projection
+  def this(tolerance: Double = 1e-6,
+  m: Int = 10,
+  initFeas: Boolean = false,
+  testOpt: Boolean = true,
+  maxIter: Int = -1,
+  maxSrchIt: Int = 50,
+  gamma: Double = 1e-4,
+  projection: DenseVector[Double] => DenseVector[Double] = identity,
+  relativeTolerance: Boolean = true)
+  (implicit space: MutableInnerProductModule[DenseVector[Double],Double]) = this(
+    convergenceCheck = FirstOrderMinimizer.defaultConvergenceCheck[DenseVector[Double], FirstOrderMinimizer[DenseVector[Double], DiffFunction[DenseVector[Double]]]#History](maxIter, tolerance, relativeTolerance),
+    m = m,
+    initFeas = initFeas,
+    testOpt = testOpt,
+    maxSrchIt = maxSrchIt,
+    gamma = gamma,
+    projection = projection,
+    innerOptimizer = new SpectralProjectedGradient[DenseVector[Double]](
+      tolerance = tolerance,
+      maxIter = 50,
+      bbMemory = 5,
+      initFeas = true,
+      minImprovementWindow = 10,
+      projection = projection
+    )
   )
 
   type History = CompactHessian
@@ -183,4 +201,3 @@ object ProjectedQuasiNewton extends SerializableLogging {
     }
   }
 }
-


### PR DESCRIPTION
So here is a first shot at what an API for picking custom convergence criteria could look like.
I'm not expecting this PR to be merged as is, but rather as something to discuss and improve.
Especially I'm not very proud of the type boilerplate (passing [T, History] around every where and even worse the FirstOrderMinimizer[T, DF]#History thing) so maybe someone with more Scala types proficiency can come up with a nicer solution.