### PR TITLE
Move scala versions into shared Build.scala file

### DIFF
--- a/benchmark/build.sbt
+++ b/benchmark/build.sbt
@@ -3,9 +3,9 @@ organization := "org.scalanlp"
 // lazy val breeze = project in file("core")
 name := "breeze-benchmark"
 
-scalaVersion := "2.11.5"
+scalaVersion := Common.scalaVersion
 
-crossScalaVersions  := Seq("2.11.5", "2.10.4")
+crossScalaVersions  := Common.crossScalaVersions
 
 addCompilerPlugin("org.scalamacros" %% "paradise" % "2.0.1" cross CrossVersion.full)
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,9 @@ lazy val viz = project.in( file("viz")).dependsOn(math)
 
 lazy val benchmark = project.in(file("benchmark")).dependsOn(math, natives)
 
-scalaVersion := "2.11.4"
+scalaVersion := Common.scalaVersion
 
-crossScalaVersions  := Seq("2.11.4", "2.10.4")
+crossScalaVersions  := Common.crossScalaVersions
 
 addCompilerPlugin("org.scalamacros" %% "paradise" % "2.0.1" cross CrossVersion.full)
 

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -21,9 +21,9 @@ libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) =>
   }
 }
 
-scalaVersion := "2.11.4"
+scalaVersion := Common.scalaVersion
 
-crossScalaVersions  := Seq("2.11.4", "2.10.4")
+crossScalaVersions  := Common.crossScalaVersions
 
 libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % "1.11.3" % "test",

--- a/math/build.sbt
+++ b/math/build.sbt
@@ -2,9 +2,9 @@ organization := "org.scalanlp"
 
 name := "breeze"
 
-scalaVersion := "2.11.5"
+scalaVersion := Common.scalaVersion
 
-crossScalaVersions  := Seq("2.11.5", "2.10.4")
+crossScalaVersions  := Common.crossScalaVersions
 
 addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0-M1" cross CrossVersion.full)
 

--- a/natives/build.sbt
+++ b/natives/build.sbt
@@ -2,9 +2,9 @@ organization := "org.scalanlp"
 
 name := "breeze-natives"
 
-scalaVersion := "2.11.5"
+scalaVersion := Common.scalaVersion
 
-crossScalaVersions  := Seq("2.11.5", "2.10.4")
+crossScalaVersions  := Common.crossScalaVersions
 
 addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0-M1" cross CrossVersion.full)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,0 +1,4 @@
+object Common {
+  val crossScalaVersions = Seq("2.11.5", "2.10.4")
+  val scalaVersion = crossScalaVersions.head
+}

--- a/viz/build.sbt
+++ b/viz/build.sbt
@@ -19,9 +19,9 @@ libraryDependencies ++= Seq(
     "com.lowagie" % "itext" % "2.1.5" intransitive()  // for pdf gen
 )
 
-scalaVersion := "2.11.5"
+scalaVersion := Common.scalaVersion
 
-crossScalaVersions  := Seq("2.11.5", "2.10.4")
+crossScalaVersions  := Common.crossScalaVersions
 
 libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _)
 


### PR DESCRIPTION
This one should prevent having to repeat Scala versions in every sub-project.