### PR TITLE
Made DenseMatrix.equal accept all matrix types (analogous to DenseVec…

### DIFF
--- a/math/src/main/scala/breeze/linalg/DenseMatrix.scala
+++ b/math/src/main/scala/breeze/linalg/DenseMatrix.scala
@@ -209,7 +209,7 @@ final class DenseMatrix[@spec(Double, Int, Float, Long) V](val rows: Int,
   def trace(implicit numeric: Numeric[V]): V = diag(this:DenseMatrix[V]).sum
 
   override def equals(p1: Any) = p1 match {
-    case x: DenseMatrix[_] =>
+    case x: Matrix[_] =>
       // todo: make this faster in obvious cases
       rows == x.rows && cols == x.cols && (valuesIterator sameElements x.valuesIterator )
 


### PR DESCRIPTION
…tor.equals).

There is no fallback for Matrix[T]. Since the implementation of DenseVector has an implementation I guess that this is the intended behavior.

scala> import breeze.linalg._
import breeze.linalg._

<pre>
scala> val a = DenseVector.zeros[Double](10)
a: breeze.linalg.DenseVector[Double] = DenseVector(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)

scala> val b = SparseVector.zeros[Double](10)
b: breeze.linalg.SparseVector[Double] = SparseVector()

scala> a == b
res1: Boolean = true

scala> val a = DenseMatrix.zeros[Double](10, 10)
a: breeze.linalg.DenseMatrix[Double] = 
0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  
0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  
0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  
0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  
0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  
0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  
0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  
0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  
0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  
0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  

scala> val b = CSCMatrix.zeros[Double](10, 10)
b: breeze.linalg.CSCMatrix[Double] = 10 x 10 CSCMatrix

scala> a == b
res2: Boolean = false
</pre>

Also see:
<strong>DenseVector.scala</strong>
<pre>
override def equals(p1: Any) = p1 match {
    case y: DenseVector[_] =>
      y.length == length && ArrayUtil.nonstupidEquals(data, offset, stride, length, y.data, y.offset, y.stride, y.length)
    case x: Vector[_] =>
//      length == x.length && (( stride == x.stride
//        && offset == x.offset
//        && data.length == x.data.length
//        && ArrayUtil.equals(data, x.data)
//      )  ||  (
          valuesIterator sameElements x.valuesIterator
//        ))

    case _ => false
  }
</pre>
