### PR TITLE
Fix StudentsT distribution pdf

### DIFF
--- a/math/src/main/scala/breeze/stats/distributions/StudentsT.scala
+++ b/math/src/main/scala/breeze/stats/distributions/StudentsT.scala
@@ -39,7 +39,7 @@ case class StudentsT(degreesOfFreedom: Double)(implicit randBasis: RandBasis = R
 
   def unnormalizedLogPdf(x: Double): Double = -(degreesOfFreedom  + 1)/2 * math.log(1 + (x * x)/degreesOfFreedom)
 
-  lazy val logNormalizer: Double = math.sqrt(math.Pi * degreesOfFreedom) + lgamma((degreesOfFreedom / 2) - lgamma(degreesOfFreedom + 1)/2)
+  lazy val logNormalizer: Double = math.sqrt(math.Pi * degreesOfFreedom) + lgamma(degreesOfFreedom / 2) - lgamma((degreesOfFreedom + 1)/2)
 
   def mean: Double = innerInstance.getNumericalMean
 


### PR DESCRIPTION
The parentheses were slightly off.

Side note:
It would be good to add a mechanism testing pdf's at a global scale in the `distributions` package.
Similarly to what is done for cdf's, we could compare the `pdf` method to the `draw` method.

About Content Square:
We are a French company aiming at improving the UX on our customers' websites. We provide insights and recommendations based on the browsing behaviors of the users. We use Scala and Spark for our data pipeline and plan to rely on Breeze and MLLib for our analysis tools. We'd be happy to contribute to Breeze on a regular basis!

http://www.contentsquare.com/en/