### PR TITLE
Bugfix: Replaced Math.abs, because it does not properly map Long.MinV…

### DIFF
--- a/math/src/main/scala/breeze/stats/distributions/Rand.scala
+++ b/math/src/main/scala/breeze/stats/distributions/Rand.scala
@@ -264,21 +264,39 @@ class RandBasis(val generator: RandomGenerator) {
    * Uniformly samples a long integer in [0,MAX_LONG]
    */
   val randLong: Rand[Long] = new Rand[Long] {
-    def draw = Math.abs(generator.nextLong)
+    def draw = {
+      var value = generator.nextLong
+      if (value < 0L) {
+        value -= Long.MinValue
+      }
+      value
+    }
   }
 
   /**
    * Uniformly samples a long integer in [0,n)
    */
   def randLong(n: Long): Rand[Long] = new Rand[Long] {
-    def draw = Math.abs(generator.nextLong) % n
+    def draw = {
+      var value = generator.nextLong
+      if (value < 0L) {
+        value -= Long.MinValue
+      }
+      value % n
+    }
   }
 
   /**
    * Uniformly samples a long integer in [n,m)
    */
   def randLong(n: Long, m: Long): Rand[Long] = new Rand[Long] {
-    def draw = Math.abs(generator.nextLong) % (m - n) + n
+    def draw = {
+      var value = generator.nextLong
+      if (value < 0L) {
+        value -= Long.MinValue
+      }
+      value % (m - n) + n
+    }
   }
 
   /**


### PR DESCRIPTION
…alue into a positive range.

Well, I think this squashes the last bug. Why is always the easy things that make the most trouble?
Also see here: https://github.com/scalanlp/breeze/pull/429
