### PR TITLE
Add cast for matrix operations

### DIFF
--- a/math/src/main/scala/breeze/linalg/operators/MatrixOps.scala
+++ b/math/src/main/scala/breeze/linalg/operators/MatrixOps.scala
@@ -1,5 +1,8 @@
 package breeze.linalg.operators
 
+import breeze.generic.UFunc
+import breeze.generic.UFunc.UImpl2
+
 import scala.reflect.ClassTag
 import breeze.linalg.support.{LiteralRow, CanCopy}
 import breeze.storage.Zero
@@ -100,6 +103,18 @@ trait MatrixGenericOps { this: Matrix.type =>
       }
 
     }
+  }
+
+  implicit def castOps[M1, M2, T, Op <: OpType, MR](implicit v1ev: M1<:<Matrix[T],
+                                                    v2ev: M2<:<Matrix[T],
+                                                    op: UImpl2[Op, Matrix[T], Matrix[T], MR]): UImpl2[Op, M1, M2, MR] = {
+    op.asInstanceOf[UFunc.UImpl2[Op, M1, M2, MR]]
+  }
+
+  implicit def castUpdateOps[M1, M2, T, Op <: OpType](implicit v1ev: M1<:<Matrix[T],
+                                                      v2ev: M2<:<Matrix[T],
+                                                      op: UFunc.InPlaceImpl2[Op, Matrix[T], Matrix[T]]): UFunc.InPlaceImpl2[Op, M1, M2] = {
+    op.asInstanceOf[UFunc.InPlaceImpl2[Op, M1, M2]]
   }
 }
 
@@ -410,5 +425,4 @@ trait MatrixMultOps extends MatrixOps with MatrixOpsLowPrio { this: Matrix.type 
       res
     }
   }
-
 }

--- a/math/src/test/scala/breeze/linalg/SliceMatrixTest.scala
+++ b/math/src/test/scala/breeze/linalg/SliceMatrixTest.scala
@@ -33,4 +33,23 @@ class SliceMatrixTest extends FunSuite {
     assert( tempDM( 0, -5 ) == 0, "Failed> tempDM( 0, -5 ) =  " + tempDM( 0, -5 ) )
   }
 
+  test("operations on slices"){
+    val a = DenseMatrix.ones[Double](5,5)
+    val b = DenseMatrix.ones[Double](5,5)
+    val indices = Seq(0,1)
+
+    val expected = DenseMatrix.ones[Double](5,5)
+
+    for (row <- indices; col <- indices) {
+      expected(row, col) += 1
+    }
+
+    val as = a(indices, indices)
+    val bs = b(indices, indices)
+
+    as += bs
+
+    assert(expected.equals(a), "Failed to execute the addition on the slices")
+  }
+
  }


### PR DESCRIPTION
Relates #464.

Breeze's matrix operations don't allow to be applied to subtypes of matrices if they are not particularly instantiated for them. Therefore this commit adds a cast operation which allows to apply operations defined for a base class to any subtype.