### PR TITLE
Sparse matrix equality efficient

### DIFF
--- a/math/src/main/scala/breeze/linalg/CSCMatrix.scala
+++ b/math/src/main/scala/breeze/linalg/CSCMatrix.scala
@@ -243,6 +243,37 @@ class CSCMatrix[@spec(Double, Int, Float, Long) V: Zero](private var _data: Arra
     }
     res
   }
+
+  override def equals(p1 : Any) : Boolean = p1 match {
+    case y: CSCMatrix[_] =>
+      if(this.rows != y.rows || this.cols != y.cols){
+        return false
+      } else {
+        val xIter = this.activeIterator
+        val yIter = y.activeIterator
+
+        while(xIter.hasNext && yIter.hasNext){
+          var xkeyval = xIter.next()
+          var ykeyval = yIter.next()
+          while(xkeyval._2 == 0 && xIter.hasNext) xkeyval = xIter.next()
+          while(ykeyval._2 == 0 && yIter.hasNext) ykeyval = yIter.next()
+          if(xkeyval != ykeyval) return false
+        }
+        if(xIter.hasNext && !yIter.hasNext){
+          while(xIter.hasNext) if(xIter.next()._2 != 0) return false
+        }
+
+        if(!xIter.hasNext && yIter.hasNext){
+          while(yIter.hasNext) if(yIter.next()._2 != 0) return false
+        }
+      }
+      return true
+    case y: Matrix[_] =>
+      return y == this
+    case _ =>
+      return false
+  }
+
 }
 
 object CSCMatrix extends MatrixConstructors[CSCMatrix]

--- a/math/src/main/scala/breeze/linalg/Matrix.scala
+++ b/math/src/main/scala/breeze/linalg/Matrix.scala
@@ -131,33 +131,10 @@ trait Matrix[@spec(Double, Int, Float, Long) V] extends MatrixLike[V, Matrix[V]]
 
   def flatten(view: View=View.Prefer): Vector[V]
 
-  override def equals(p1: Any) : Boolean = (this, p1) match {
-    case (x: CSCMatrix[V], y: CSCMatrix[V]) =>
-      if(x.rows != y.rows || x.cols != y.cols){
-        return false
-      } else {
-        val xIter = x.activeIterator
-        val yIter = y.activeIterator
-
-        while(xIter.hasNext && yIter.hasNext){
-          var xkeyval = xIter.next()
-          var ykeyval = yIter.next()
-          while(xkeyval._2 == 0 && xIter.hasNext) xkeyval = xIter.next()
-          while(ykeyval._2 == 0 && yIter.hasNext) ykeyval = yIter.next()
-          if(xkeyval != ykeyval) return false
-        }
-        if(xIter.hasNext && !yIter.hasNext){
-          while(xIter.hasNext) if(xIter.next()._2 != 0) return false
-        }
-
-        if(!xIter.hasNext && yIter.hasNext){
-          while(yIter.hasNext) if(yIter.next()._2 != 0) return false
-        }
-      }
-      return true
-    case (x: Matrix[V], y: Matrix[_]) =>
-      x.rows == y.rows && x.cols == y.cols &&
-        keysIterator.forall(k => x(k) == y(k))
+  override def equals(p1: Any) : Boolean = p1 match {
+    case x: Matrix[_] =>
+      this.rows == x.rows && this.cols == x.cols &&
+        keysIterator.forall(k => this(k) == x(k))
     case _ =>
       return false
   }

--- a/math/src/main/scala/breeze/linalg/Matrix.scala
+++ b/math/src/main/scala/breeze/linalg/Matrix.scala
@@ -131,7 +131,7 @@ trait Matrix[@spec(Double, Int, Float, Long) V] extends MatrixLike[V, Matrix[V]]
 
   def flatten(view: View=View.Prefer): Vector[V]
 
-  override def equals(p1: Any) = p1 match {
+  override def equals(p1: Any) = (this, p1) match {
     case (x: CSCMatrix[V], p1: CSCMatrix[V]) =>
       x.rows == p1.rows && x.cols == p1.cols && x.activeSize == p1.activeSize &&
         activeKeysIterator.forall(k => this(k) == x(k))

--- a/math/src/main/scala/breeze/linalg/Matrix.scala
+++ b/math/src/main/scala/breeze/linalg/Matrix.scala
@@ -131,15 +131,35 @@ trait Matrix[@spec(Double, Int, Float, Long) V] extends MatrixLike[V, Matrix[V]]
 
   def flatten(view: View=View.Prefer): Vector[V]
 
-  override def equals(p1: Any) = (this, p1) match {
-    case (x: CSCMatrix[V], p1: CSCMatrix[_]) =>
-      x.rows == p1.rows && x.cols == p1.cols && x.activeSize == p1.activeSize &&
-        activeKeysIterator.forall(k => x(k) == p1(k))
-    case (x: Matrix[V], p1: Matrix[_]) =>
-      x.rows == p1.rows && x.cols == p1.cols &&
-        keysIterator.forall(k => x(k) == p1(k))
+  override def equals(p1: Any) : Boolean = (this, p1) match {
+    case (x: CSCMatrix[V], y: CSCMatrix[V]) =>
+      if(x.rows != y.rows || x.cols != y.cols){
+        return false
+      } else {
+        val xIter = x.activeIterator
+        val yIter = y.activeIterator
+
+        while(xIter.hasNext && yIter.hasNext){
+          var xkeyval = xIter.next()
+          var ykeyval = yIter.next()
+          while(xkeyval._2 == 0 && xIter.hasNext) xkeyval = xIter.next()
+          while(ykeyval._2 == 0 && yIter.hasNext) ykeyval = yIter.next()
+          if(xkeyval != ykeyval) return false
+        }
+        if(xIter.hasNext == true && yIter.hasNext == false){
+          while(xIter.hasNext) if(xIter.next()._2 != 0) return false
+        }
+
+        if(xIter.hasNext == false && yIter.hasNext == true){
+          while(yIter.hasNext) if(yIter.next()._2 != 0) return false
+        }
+      }
+      return true
+    case (x: Matrix[V], y: Matrix[_]) =>
+      x.rows == y.rows && x.cols == y.cols &&
+        keysIterator.forall(k => x(k) == y(k))
     case _ =>
-      false
+      return false
   }
 
 }

--- a/math/src/main/scala/breeze/linalg/Matrix.scala
+++ b/math/src/main/scala/breeze/linalg/Matrix.scala
@@ -132,13 +132,14 @@ trait Matrix[@spec(Double, Int, Float, Long) V] extends MatrixLike[V, Matrix[V]]
   def flatten(view: View=View.Prefer): Vector[V]
 
   override def equals(p1: Any) = (this, p1) match {
-    case (x: CSCMatrix[V], p1: CSCMatrix[V]) =>
+    case (x: CSCMatrix[V], p1: CSCMatrix[_]) =>
       x.rows == p1.rows && x.cols == p1.cols && x.activeSize == p1.activeSize &&
-        activeKeysIterator.forall(k => this(k) == x(k))
+        activeKeysIterator.forall(k => x(k) == p1(k))
     case (x: Matrix[V], p1: Matrix[_]) =>
       x.rows == p1.rows && x.cols == p1.cols &&
-        keysIterator.forall(k => this(k) == x(k))
-    case _ => false
+        keysIterator.forall(k => x(k) == p1(k))
+    case _ =>
+      false
   }
 
 }

--- a/math/src/main/scala/breeze/linalg/Matrix.scala
+++ b/math/src/main/scala/breeze/linalg/Matrix.scala
@@ -132,8 +132,11 @@ trait Matrix[@spec(Double, Int, Float, Long) V] extends MatrixLike[V, Matrix[V]]
   def flatten(view: View=View.Prefer): Vector[V]
 
   override def equals(p1: Any) = p1 match {
-    case x: Matrix[_] =>
-      this.rows == x.rows && this.cols == x.cols &&
+    case (x: CSCMatrix[V], p1: CSCMatrix[V]) =>
+      x.rows == p1.rows && x.cols == p1.cols && x.activeSize == p1.activeSize &&
+        activeKeysIterator.forall(k => this(k) == x(k))
+    case (x: Matrix[V], p1: Matrix[_]) =>
+      x.rows == p1.rows && x.cols == p1.cols &&
         keysIterator.forall(k => this(k) == x(k))
     case _ => false
   }

--- a/math/src/main/scala/breeze/linalg/Matrix.scala
+++ b/math/src/main/scala/breeze/linalg/Matrix.scala
@@ -146,11 +146,11 @@ trait Matrix[@spec(Double, Int, Float, Long) V] extends MatrixLike[V, Matrix[V]]
           while(ykeyval._2 == 0 && yIter.hasNext) ykeyval = yIter.next()
           if(xkeyval != ykeyval) return false
         }
-        if(xIter.hasNext == true && yIter.hasNext == false){
+        if(xIter.hasNext && !yIter.hasNext){
           while(xIter.hasNext) if(xIter.next()._2 != 0) return false
         }
 
-        if(xIter.hasNext == false && yIter.hasNext == true){
+        if(!xIter.hasNext && yIter.hasNext){
           while(yIter.hasNext) if(yIter.next()._2 != 0) return false
         }
       }

--- a/math/src/test/scala/breeze/linalg/MatrixTest.scala
+++ b/math/src/test/scala/breeze/linalg/MatrixTest.scala
@@ -140,9 +140,15 @@ class MatrixTest extends FunSuite with Checkers {
     val v2: CSCMatrix[Int] = CSCMatrix(0, 2, 0, 0, 3)
     val diff = v - v2
     val zeros = CSCMatrix.zeros[Int](5, 1)
-    assert(v == v2)
-    assert(diff == zeros)
+    val v4 = v2.copy
+    v4.update(1, 0, 0)
+    v4.update(4, 0, 0)
+    assert(v == v2) // similar matrices are same
+    assert(diff == zeros) // automatic removal of explicit zeros
     assert(diff.activeSize == 0)
+    assert(zeros == v4) // implicit vs explicit
+    assert(v4 == zeros) // explicit vs implicit
+    assert(zeros != v)
   }
 
 //  test("MapValues") {

--- a/math/src/test/scala/breeze/linalg/MatrixTest.scala
+++ b/math/src/test/scala/breeze/linalg/MatrixTest.scala
@@ -130,6 +130,26 @@ class MatrixTest extends FunSuite with Checkers {
     assert(v.hashCode == v2.hashCode)
   }
 
+  test("Sparse equality") {
+    val v: CSCMatrix[Int] = {
+      val mt = new CSCMatrix.Builder[Int](5, 1)
+      mt.add(1, 0, 2)
+      mt.add(4, 0, 3)
+      mt.result
+    }
+    val v2: CSCMatrix[Int] = {
+      val mt = new CSCMatrix.Builder[Int](5, 1)
+      mt.add(1, 0, 2)
+      mt.add(4, 0, 3)
+      mt.result
+    }
+    v2(0,0) = 0
+    val diff = v - v2
+    val zeros = CSCMatrix.zeros[Int](5, 1)
+    assert(v == v2)
+    assert(diff == zeros)
+    assert(diff.activeSize == 0)
+  }
 
 //  test("MapValues") {
 //    val a : Matrix[Int] = Matrix((1,0,0),(2,3,-1))

--- a/math/src/test/scala/breeze/linalg/MatrixTest.scala
+++ b/math/src/test/scala/breeze/linalg/MatrixTest.scala
@@ -137,13 +137,7 @@ class MatrixTest extends FunSuite with Checkers {
       mt.add(4, 0, 3)
       mt.result
     }
-    val v2: CSCMatrix[Int] = {
-      val mt = new CSCMatrix.Builder[Int](5, 1)
-      mt.add(1, 0, 2)
-      mt.add(4, 0, 3)
-      mt.result
-    }
-    v2(0,0) = 0
+    val v2: CSCMatrix[Int] = CSCMatrix(0, 2, 0, 0, 3)
     val diff = v - v2
     val zeros = CSCMatrix.zeros[Int](5, 1)
     assert(v == v2)


### PR DESCRIPTION
This is a pull request that originates from a requirement in Spark for a more efficient SparseMatrix equality check. When comparing two CSCMatrices, use activeKeysIterator instead of keysIterator. This will return and check the non-zero-value keys in the SparseMatrix. An extra conditional is introduced to make sure the active size of both SparseMatrices are the same.

I tried to to implement the case where equality needed to be checked between a SparseMatrix and DenseMatrix. However, I couldn't find a way of doing this without traversing the DenseMatrix at least once. 
