### PR TITLE
adds ability to set custom seed via:  RandBasis.withSeed(...)

### DIFF
--- a/math/src/main/scala/breeze/stats/distributions/Rand.scala
+++ b/math/src/main/scala/breeze/stats/distributions/Rand.scala
@@ -356,4 +356,11 @@ object RandBasis {
     new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(int.getAndIncrement())))
   }
 
+  /**
+   * Returns a new MersenneTwister backed rand basis with seed set to a specific value
+   */
+  def withSeed(seed: Int) = {
+    new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(seed)))
+  }
+
 }

--- a/math/src/main/scala/breeze/stats/distributions/Rand.scala
+++ b/math/src/main/scala/breeze/stats/distributions/Rand.scala
@@ -360,7 +360,8 @@ object RandBasis {
    * Returns a new MersenneTwister backed rand basis with seed set to a specific value
    */
   def withSeed(seed: Int) = {
-    new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(seed)))
+    val int = new AtomicInteger(seed)
+    new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(int.getAndIncrement())))
   }
 
 }

--- a/math/src/test/scala/breeze/stats/distributions/RandTest.scala
+++ b/math/src/test/scala/breeze/stats/distributions/RandTest.scala
@@ -31,6 +31,23 @@ class RandTest extends FunSuite {
     assert( RandBasis.mt0.randLong.sample(10000).forall(_ >= 0) )
   }
 
+  test("RandBasis.withSeed ensures distinct seeds in different threads") {
+    implicit val basis: RandBasis = RandBasis.withSeed(2)
+    var t2 = new Gaussian(0, 1).sample(10)
+    var t3 = new Gaussian(0, 1).sample(10)
+
+    assert { t2 != t3 }  // sanity check
+
+    val threads = for (i <- 1 to 2) yield new Thread {
+      override def run() { t2 = new Gaussian(0, 1).sample(10) }
+    }
+    threads map(_.start)
+    threads map(_.join)
+
+    // ensure that both threads use different seeds
+    assert { t2 != t3 }
+  }
+
   test("RandBasis.withSeed lets users specify a random seed") {
     {
       val a = RandBasis.withSeed(0).randInt.sample(100)

--- a/math/src/test/scala/breeze/stats/distributions/RandTest.scala
+++ b/math/src/test/scala/breeze/stats/distributions/RandTest.scala
@@ -27,8 +27,22 @@ import org.scalatest.FunSuite
  **/
 class RandTest extends FunSuite {
   test("randInt is always non-negative") {
-    RandBasis.mt0.randInt.sample(10000).forall(_ >= 0)
-    RandBasis.mt0.randLong.sample(10000).forall(_ >= 0)
+    assert( RandBasis.mt0.randInt.sample(10000).forall(_ >= 0) )
+    assert( RandBasis.mt0.randLong.sample(10000).forall(_ >= 0) )
+  }
+
+  test("RandBasis.withSeed lets users specify a random seed") {
+    {
+      val a = RandBasis.withSeed(0).randInt.sample(100)
+      val b = RandBasis.withSeed(0).randInt.sample(100)
+      assert(a == b)
+    }
+
+    {
+      val a = RandBasis.withSeed(0).randInt.sample(100)
+      val b = RandBasis.withSeed(1).randInt.sample(100)
+      assert(a != b)
+    }
   }
 
 }


### PR DESCRIPTION
closes #492 

adds RandBasis.withSeed(...) to enable functionality like:

```
import breeze.stats.distributions.{Uniform, RandBasis}

val uniform1 = new Uniform(0, 1)(RandBasis.withSeed(0))
val uniform2 = new Uniform(0, 1)(RandBasis.withSeed(0))

assert { uniform1.sample(100) == uniform2.sample(100) }
```

@dlwh you mentioned in #492 that _The atomic integer is important because with your code every thread gets its own random generator with the same seed._  I wanted to be able to have all threads use the same seed.  If users care to define a starting seed and also to ensure threads have different seeds, I think they can can wrap calls to withSeed like this `withSeed(atomicInt.getAndIncrement())`.  Can you please let me know if I misinterpreted anything, and also let me know if should change the code?

Thank you!