### PR TITLE
bump shapeless 2.0.0 -> 2.2.5

### DIFF
--- a/math/build.sbt
+++ b/math/build.sbt
@@ -66,7 +66,7 @@ libraryDependencies ++= Seq(
 libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) =>
   sv match {
     case x if x startsWith "2.10" =>
-      (deps :+ ("com.chuusai" %% "shapeless" % "2.2.0" cross CrossVersion.full))
+      (deps :+ ("com.chuusai" %% "shapeless" % "2.0.0" cross CrossVersion.full))
     case x if x.startsWith("2.11") =>
       (deps :+ ("com.chuusai" %% "shapeless" % "2.2.5" ))
     case _       =>

--- a/math/build.sbt
+++ b/math/build.sbt
@@ -66,7 +66,7 @@ libraryDependencies ++= Seq(
 libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) =>
   sv match {
     case x if x startsWith "2.10" =>
-      (deps :+ ("com.chuusai" %% "shapeless" % "2.2.5" cross CrossVersion.full))
+      (deps :+ ("com.chuusai" %% "shapeless" % "2.3.0" cross CrossVersion.full))
     case x if x.startsWith("2.11") =>
       (deps :+ ("com.chuusai" %% "shapeless" % "2.2.5" ))
     case _       =>

--- a/math/build.sbt
+++ b/math/build.sbt
@@ -66,7 +66,7 @@ libraryDependencies ++= Seq(
 libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) =>
   sv match {
     case x if x startsWith "2.10" =>
-      (deps :+ ("com.chuusai" %% "shapeless" % "2.3.0" cross CrossVersion.full))
+      (deps :+ ("com.chuusai" %% "shapeless" % "2.2.0" cross CrossVersion.full))
     case x if x.startsWith("2.11") =>
       (deps :+ ("com.chuusai" %% "shapeless" % "2.2.5" ))
     case _       =>

--- a/math/build.sbt
+++ b/math/build.sbt
@@ -66,9 +66,9 @@ libraryDependencies ++= Seq(
 libraryDependencies <<= (scalaVersion, libraryDependencies) { (sv, deps) =>
   sv match {
     case x if x startsWith "2.10" =>
-      (deps :+ ("com.chuusai" %% "shapeless" % "2.0.0" cross CrossVersion.full))
+      (deps :+ ("com.chuusai" %% "shapeless" % "2.2.5" cross CrossVersion.full))
     case x if x.startsWith("2.11") =>
-      (deps :+ ("com.chuusai" %% "shapeless" % "2.0.0" ))
+      (deps :+ ("com.chuusai" %% "shapeless" % "2.2.5" ))
     case _       =>
       deps
   }


### PR DESCRIPTION
Bumping the shapeless version after running into versioning issues `java.lang.NoSuchMethodError: shapeless.Witness$.mkWitness(Ljava/lang/Object;)Lshapeless/Witness;` with another dependency. 

Tests pass after bumping.