### PR TITLE
Deprecate elementwise operators starting with colon to fix operator precedence

### DIFF
--- a/math/src/main/scala/breeze/linalg/NumericOps.scala
+++ b/math/src/main/scala/breeze/linalg/NumericOps.scala
@@ -277,8 +277,8 @@ trait NumericOps[+This] extends ImmutableNumericOps[This] {
   final def :<[TT >: This, B, That](b: B)(implicit op: OpLT.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise less-than-or-equal-to comparator of this and b. */
-  final def <=:<=[TT >: This, B, That](b: B)(implicit op: OpLTE.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use <=:<= instead", "0.13")
+  final def <:=[TT >: This, B, That](b: B)(implicit op: OpLTE.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use <:= instead", "0.13")
   final def :<=[TT >: This, B, That](b: B)(implicit op: OpLTE.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise greater-than comparator of this and b. */
@@ -287,8 +287,8 @@ trait NumericOps[+This] extends ImmutableNumericOps[This] {
   final def :>[TT >: This, B, That](b: B)(implicit op: OpGT.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise greater-than-or-equal-to comparator of this and b. */
-  final def >=:>=[TT >: This, B, That](b: B)(implicit op: OpGTE.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use >=:>= instead", "0.13")
+  final def >:=[TT >: This, B, That](b: B)(implicit op: OpGTE.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use >:= instead", "0.13")
   final def :>=[TT >: This, B, That](b: B)(implicit op: OpGTE.Impl2[TT, B, That]) = op(repr, b)
 
 

--- a/math/src/main/scala/breeze/linalg/NumericOps.scala
+++ b/math/src/main/scala/breeze/linalg/NumericOps.scala
@@ -29,9 +29,13 @@ trait ImmutableNumericOps[+This] extends Any {
 
   // Immutable
   /** Element-wise sum of this and b. */
+  final def +:+[TT >: This, B, That](b: B)(implicit op: OpAdd.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use +:+ instead", "0.13")
   final def :+[TT >: This, B, That](b: B)(implicit op: OpAdd.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise product of this and b. */
+  final def *:*[TT >: This, B, That](b: B)(implicit op: OpMulScalar.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use *:* instead", "0.13")
   final def :*[TT >: This, B, That](b: B)(implicit op: OpMulScalar.Impl2[TT, B, That]) = op(repr, b)
 
 
@@ -48,6 +52,8 @@ trait ImmutableNumericOps[+This] extends Any {
   final def unary_-[TT >: This, That](implicit op: OpNeg.Impl[TT, That]) = op(repr)
 
   /** Element-wise difference of this and b. */
+  final def -:-[TT >: This, B, That](b: B)(implicit op: OpSub.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use -:- instead", "0.13")
   final def :-[TT >: This, B, That](b: B)(implicit op: OpSub.Impl2[TT, B, That]) = op(repr, b)
 
   /** Alias for :-(b) for all b. */
@@ -56,6 +62,8 @@ trait ImmutableNumericOps[+This] extends Any {
   }
 
   /** Element-wise modulo of this and b. */
+  final def %:%[TT >: This, B, That](b: B)(implicit op: OpMod.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use %:% instead", "0.13")
   final def :%[TT >: This, B, That](b: B)(implicit op: OpMod.Impl2[TT, B, That]) = op(repr, b)
 
   /** Alias for :%(b) when b is a scalar. */
@@ -71,6 +79,8 @@ trait ImmutableNumericOps[+This] extends Any {
 
   // Immutable
   /** Element-wise quotient of this and b. */
+  final def /:/[TT >: This, B, That](b: B)(implicit op: OpDiv.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use /:/ instead", "0.13")
   final def :/[TT >: This, B, That](b: B)(implicit op: OpDiv.Impl2[TT, B, That]) = op(repr, b)
 
   /** Alias for :/(b) when b is a scalar. */
@@ -79,6 +89,8 @@ trait ImmutableNumericOps[+This] extends Any {
   }
 
   /** Element-wise exponentiation of this and b. */
+  final def ^:^[TT >: This, B, That](b: B)(implicit op: OpPow.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use ^:^ instead", "0.13")
   final def :^[TT >: This, B, That](b: B)(implicit op: OpPow.Impl2[TT, B, That]) = op(repr, b)
 
 
@@ -104,12 +116,18 @@ trait ImmutableNumericOps[+This] extends Any {
   final def unary_![TT >: This, That](implicit op: OpNot.Impl[TT, That]) = op(repr)
 
   /** Element-wise logical "and" operator -- returns true if corresponding elements are non-zero. */
+  final def &:&[TT >: This, B, That](b: B)(implicit op: OpAnd.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use &:& instead", "0.13")
   final def :&[TT >: This, B, That](b: B)(implicit op: OpAnd.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise logical "or" operator -- returns true if either element is non-zero. */
+  final def |:|[TT >: This, B, That](b: B)(implicit op: OpOr.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use |:| instead", "0.13")
   final def :|[TT >: This, B, That](b: B)(implicit op: OpOr.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise logical "xor" operator -- returns true if only one of the corresponding elements is non-zero. */
+  final def ^^:^^[TT >: This, B, That](b: B)(implicit op: OpXor.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use ^^:^^ instead", "0.13")
   final def :^^[TT >: This, B, That](b: B)(implicit op: OpXor.Impl2[TT, B, That]) = op(repr, b)
 
   /** Alias for :&&(b) for all b. */
@@ -254,15 +272,23 @@ trait NumericOps[+This] extends ImmutableNumericOps[This] {
    */
 
   /** Element-wise less=than comparator of this and b. */
+  final def <:<[TT >: This, B, That](b: B)(implicit op: OpLT.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use <:< instead", "0.13")
   final def :<[TT >: This, B, That](b: B)(implicit op: OpLT.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise less-than-or-equal-to comparator of this and b. */
+  final def <=:<=[TT >: This, B, That](b: B)(implicit op: OpLTE.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use <=:<= instead", "0.13")
   final def :<=[TT >: This, B, That](b: B)(implicit op: OpLTE.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise greater-than comparator of this and b. */
+  final def >:>[TT >: This, B, That](b: B)(implicit op: OpGT.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use >:> instead", "0.13")
   final def :>[TT >: This, B, That](b: B)(implicit op: OpGT.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise greater-than-or-equal-to comparator of this and b. */
+  final def >=:>=[TT >: This, B, That](b: B)(implicit op: OpGTE.Impl2[TT, B, That]) = op(repr, b)
+  @deprecated("use >=:>= instead", "0.13")
   final def :>=[TT >: This, B, That](b: B)(implicit op: OpGTE.Impl2[TT, B, That]) = op(repr, b)
 
 

--- a/math/src/main/scala/breeze/linalg/NumericOps.scala
+++ b/math/src/main/scala/breeze/linalg/NumericOps.scala
@@ -30,12 +30,14 @@ trait ImmutableNumericOps[+This] extends Any {
   // Immutable
   /** Element-wise sum of this and b. */
   final def +:+[TT >: This, B, That](b: B)(implicit op: OpAdd.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use +:+ instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use +:+ instead.", "0.13")
   final def :+[TT >: This, B, That](b: B)(implicit op: OpAdd.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise product of this and b. */
   final def *:*[TT >: This, B, That](b: B)(implicit op: OpMulScalar.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use *:* instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use *:* instead.", "0.13")
   final def :*[TT >: This, B, That](b: B)(implicit op: OpMulScalar.Impl2[TT, B, That]) = op(repr, b)
 
 
@@ -53,7 +55,8 @@ trait ImmutableNumericOps[+This] extends Any {
 
   /** Element-wise difference of this and b. */
   final def -:-[TT >: This, B, That](b: B)(implicit op: OpSub.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use -:- instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use -:- instead.", "0.13")
   final def :-[TT >: This, B, That](b: B)(implicit op: OpSub.Impl2[TT, B, That]) = op(repr, b)
 
   /** Alias for :-(b) for all b. */
@@ -63,7 +66,8 @@ trait ImmutableNumericOps[+This] extends Any {
 
   /** Element-wise modulo of this and b. */
   final def %:%[TT >: This, B, That](b: B)(implicit op: OpMod.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use %:% instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use %:% instead.", "0.13")
   final def :%[TT >: This, B, That](b: B)(implicit op: OpMod.Impl2[TT, B, That]) = op(repr, b)
 
   /** Alias for :%(b) when b is a scalar. */
@@ -80,7 +84,8 @@ trait ImmutableNumericOps[+This] extends Any {
   // Immutable
   /** Element-wise quotient of this and b. */
   final def /:/[TT >: This, B, That](b: B)(implicit op: OpDiv.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use /:/ instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use /:/ instead.", "0.13")
   final def :/[TT >: This, B, That](b: B)(implicit op: OpDiv.Impl2[TT, B, That]) = op(repr, b)
 
   /** Alias for :/(b) when b is a scalar. */
@@ -90,7 +95,8 @@ trait ImmutableNumericOps[+This] extends Any {
 
   /** Element-wise exponentiation of this and b. */
   final def ^:^[TT >: This, B, That](b: B)(implicit op: OpPow.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use ^:^ instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use ^:^ instead.", "0.13")
   final def :^[TT >: This, B, That](b: B)(implicit op: OpPow.Impl2[TT, B, That]) = op(repr, b)
 
 
@@ -117,17 +123,20 @@ trait ImmutableNumericOps[+This] extends Any {
 
   /** Element-wise logical "and" operator -- returns true if corresponding elements are non-zero. */
   final def &:&[TT >: This, B, That](b: B)(implicit op: OpAnd.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use &:& instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use &:& instead.", "0.13")
   final def :&[TT >: This, B, That](b: B)(implicit op: OpAnd.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise logical "or" operator -- returns true if either element is non-zero. */
   final def |:|[TT >: This, B, That](b: B)(implicit op: OpOr.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use |:| instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use |:| instead.", "0.13")
   final def :|[TT >: This, B, That](b: B)(implicit op: OpOr.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise logical "xor" operator -- returns true if only one of the corresponding elements is non-zero. */
   final def ^^:^^[TT >: This, B, That](b: B)(implicit op: OpXor.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use ^^:^^ instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use ^^:^^ instead.", "0.13")
   final def :^^[TT >: This, B, That](b: B)(implicit op: OpXor.Impl2[TT, B, That]) = op(repr, b)
 
   /** Alias for :&&(b) for all b. */
@@ -273,22 +282,26 @@ trait NumericOps[+This] extends ImmutableNumericOps[This] {
 
   /** Element-wise less=than comparator of this and b. */
   final def <:<[TT >: This, B, That](b: B)(implicit op: OpLT.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use <:< instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use <:< instead.", "0.13")
   final def :<[TT >: This, B, That](b: B)(implicit op: OpLT.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise less-than-or-equal-to comparator of this and b. */
   final def <:=[TT >: This, B, That](b: B)(implicit op: OpLTE.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use <:= instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use <:= instead.", "0.13")
   final def :<=[TT >: This, B, That](b: B)(implicit op: OpLTE.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise greater-than comparator of this and b. */
   final def >:>[TT >: This, B, That](b: B)(implicit op: OpGT.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use >:> instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use >:> instead.", "0.13")
   final def :>[TT >: This, B, That](b: B)(implicit op: OpGT.Impl2[TT, B, That]) = op(repr, b)
 
   /** Element-wise greater-than-or-equal-to comparator of this and b. */
   final def >:=[TT >: This, B, That](b: B)(implicit op: OpGTE.Impl2[TT, B, That]) = op(repr, b)
-  @deprecated("use >:= instead", "0.13")
+  @deprecated(
+    "This operator has confusing and often surprising precedence that leads to bugs. Use >:= instead.", "0.13")
   final def :>=[TT >: This, B, That](b: B)(implicit op: OpGTE.Impl2[TT, B, That]) = op(repr, b)
 
 

--- a/math/src/main/scala/breeze/linalg/package.scala
+++ b/math/src/main/scala/breeze/linalg/package.scala
@@ -282,12 +282,12 @@ package object linalg {
     if (center) {
       val xc = x(*,::) - mean(x, Axis._0).t
       if (scale)
-        xc(*,::) :/ stddev(x(::, *)).t
+        xc(*,::) /:/ stddev(x(::, *)).t
       else
         xc
     } else {
       if (scale)
-        x(*,::) :/ columnRMS(x)
+        x(*,::) /:/ columnRMS(x)
       else
         x
     }
@@ -332,7 +332,7 @@ package object linalg {
    * matrix. Feel free to make this more general.
    */
   private def columnRMS(x: DenseMatrix[Double]): DenseVector[Double] =
-    (sum(x:*x,Axis._0) / (x.rows-1.0)).t.map( scala.math.sqrt _ )
+    (sum(x *:* x, Axis._0) / (x.rows - 1.0)).t.map( scala.math.sqrt _ )
 
 
   /** Alias for randomDouble */

--- a/math/src/main/scala/breeze/numerics/financial/package.scala
+++ b/math/src/main/scala/breeze/numerics/financial/package.scala
@@ -111,7 +111,7 @@ package object financial {
       //fill the 1th diagnal below the main diagnal with ones
       val downDiagIdxs = for(i <-(1 until N)) yield (i, i - 1)
       A(downDiagIdxs) := 1.0
-      A(0 until 1, ::) := nonZeroCoeffs(1 to N) :/ -nonZeroCoeffs(0)
+      A(0 until 1, ::) := nonZeroCoeffs(1 to N) /:/ -nonZeroCoeffs(0)
       val rootEig = eig(A)
 
       val nonZeroEigNum = rootEig.eigenvalues.length;

--- a/math/src/main/scala/breeze/optimize/AdaDeltaGradientDescent.scala
+++ b/math/src/main/scala/breeze/optimize/AdaDeltaGradientDescent.scala
@@ -27,20 +27,20 @@ class AdaDeltaGradientDescent[T](rho: Double,
 
   override protected def updateHistory(newX: T, newGrad: T, newVal: Double, f: StochasticDiffFunction[T], oldState: State): History = {
     val oldAvgSqGradient = oldState.history.avgSqGradient
-    val newAvgSqGradient = (oldAvgSqGradient * rho) + ((newGrad :* newGrad) * (1 - rho))
+    val newAvgSqGradient = (oldAvgSqGradient * rho) + ((newGrad *:* newGrad) * (1 - rho))
 
     val oldAvgSqDelta = oldState.history.avgSqDelta
     val delta = newX - oldState.x
-    val newAvgSqDelta = (oldAvgSqDelta * rho) + ((delta :* delta) * (1 - rho))
+    val newAvgSqDelta = (oldAvgSqDelta * rho) + ((delta *:* delta) * (1 - rho))
 
     History(newAvgSqGradient, newAvgSqDelta)
   }
 
   override protected def takeStep(state: State, dir: T, stepSize: Double): T = {
-    val newAvgSqGradient = (state.history.avgSqGradient * rho) :+ ((state.grad :* state.grad) * (1 - rho))
+    val newAvgSqGradient = (state.history.avgSqGradient * rho) +:+ ((state.grad *:* state.grad) * (1 - rho))
     val rmsGradient = sqrt(newAvgSqGradient + epsilon)
     val rmsDelta = sqrt(state.history.avgSqDelta + epsilon)
-    val delta = dir :* rmsDelta :/ rmsGradient
+    val delta = dir *:* rmsDelta /:/ rmsGradient
     state.x + delta
   }
 

--- a/math/src/main/scala/breeze/optimize/AdaptiveGradientDescent.scala
+++ b/math/src/main/scala/breeze/optimize/AdaptiveGradientDescent.scala
@@ -41,7 +41,7 @@ object AdaptiveGradientDescent {
 
     override def updateHistory(newX: T, newGrad: T, newValue: Double, f: StochasticDiffFunction[T], oldState: State) = {
       val oldHistory = oldState.history
-      val newG = (oldState.grad :* oldState.grad)
+      val newG = (oldState.grad *:* oldState.grad)
       val maxAge = 1000.0
       if(oldState.iter > maxAge) {
         newG *= 1/maxAge
@@ -54,8 +54,8 @@ object AdaptiveGradientDescent {
 
     override protected def takeStep(state: State, dir: T, stepSize: Double) = {
       import state._
-      val s = sqrt(state.history.sumOfSquaredGradients :+ (state.grad :* state.grad))
-      val newx = x :* s
+      val s = sqrt(state.history.sumOfSquaredGradients +:+ (state.grad *:* state.grad))
+      val newx = x *:* s
       axpy(stepSize, dir, newx)
       s += (delta + regularizationConstant * stepSize)
       newx :/= s
@@ -98,14 +98,14 @@ object AdaptiveGradientDescent {
     /*
     override def updateHistory(newX: T, newGrad: T, newValue: Double, oldState: State) = {
       val oldHistory = oldState.history
-      val newG = oldHistory.sumOfSquaredGradients :+ (oldState.grad :* oldState.grad)
+      val newG = oldHistory.sumOfSquaredGradients +:+ (oldState.grad *:* oldState.grad)
       new History(newG)
     }
     */
 
     override def updateHistory(newX: T, newGrad: T, newValue: Double,  f: StochasticDiffFunction[T], oldState: State) = {
       val oldHistory = oldState.history
-      val newG = (oldState.grad :* oldState.grad)
+      val newG = (oldState.grad *:* oldState.grad)
       val maxAge = 200.0
       if(oldState.iter > maxAge) {
         newG *= (1/maxAge)
@@ -118,8 +118,8 @@ object AdaptiveGradientDescent {
 
     override protected def takeStep(state: State, dir: T, stepSize: Double) = {
       import state._
-      val s:T = sqrt(state.history.sumOfSquaredGradients :+ (grad :* grad) :+ delta)
-      val res:T = x + (dir :* stepSize :/ s)
+      val s:T = sqrt(state.history.sumOfSquaredGradients +:+ (grad *:* grad) +:+ delta)
+      val res:T = x + (dir *:* stepSize /:/ s)
       val tlambda = lambda * stepSize
       space.zipMapValues.map(res, s, { case (x_half ,s_i) =>
         if(x_half.abs < tlambda / s_i) {
@@ -136,7 +136,7 @@ object AdaptiveGradientDescent {
 
     override protected def adjust(newX: T, newGrad: T, newVal: Double) = {
       val av = newVal + norm(newX, 1.0) * lambda
-      val ag = newGrad + (signum(newX) :* lambda)
+      val ag = newGrad + (signum(newX) *:* lambda)
       (av -> ag)
     }
 

--- a/math/src/main/scala/breeze/optimize/TruncatedNewtonMinimizer.scala
+++ b/math/src/main/scala/breeze/optimize/TruncatedNewtonMinimizer.scala
@@ -171,7 +171,7 @@ class TruncatedNewtonMinimizer[T, H](maxIterations: Int = -1,
   }
 
   protected def updateHistory(newX: T, newGrad: T, newVal: Double, oldState: State): History = {
-    val gradDelta : T = (newGrad :- oldState.adjGrad)
+    val gradDelta : T = (newGrad -:- oldState.adjGrad)
     val step:T = (newX - oldState.x)
 
     val memStep = (step +: oldState.history.memStep) take m

--- a/math/src/main/scala/breeze/optimize/linear/AffineScaling.scala
+++ b/math/src/main/scala/breeze/optimize/linear/AffineScaling.scala
@@ -24,7 +24,7 @@ class AffineScaling extends SerializableLogging {
     var cv = x dot c
     while(!converged) {
       val vk = b - A * x
-      val D = diag(vk :^ -2.0)
+      val D = diag(vk ^:^ -2.0)
       val hx = (A.t * D * A).asInstanceOf[DenseMatrix[Double]] \ c
       val hv:DenseVector[Double] = A * hx * -1.0
       if(hv.values.exists(_ >= 0)) throw UnboundedProblem

--- a/math/src/main/scala/breeze/optimize/linear/ConjugateGradient.scala
+++ b/math/src/main/scala/breeze/optimize/linear/ConjugateGradient.scala
@@ -67,12 +67,12 @@ class ConjugateGradient[T,M](maxNormValue: Double = Double.PositiveInfinity,
 
       assert(!alphaNext.isNaN, xtd +" " + normSquare + " " + xtx + "  " + xtd + " " + radius + " " +  dtd)
       axpy(alphaNext, d, x)
-      axpy(-alphaNext, Bd + (d :* normSquaredPenalty), r)
+      axpy(-alphaNext, Bd + (d *:* normSquaredPenalty), r)
 
       State(x, r, d, iter + 1, converged = true)
     } else {
       x := nextX
-      r -= (Bd + (d :* normSquaredPenalty)) :* alpha
+      r -= (Bd + (d *:* normSquaredPenalty)) *:* alpha
       val newrtr = r dot r
       val beta = newrtr / rtr
       d :*= beta
@@ -95,7 +95,7 @@ class ConjugateGradient[T,M](maxNormValue: Double = Double.PositiveInfinity,
   }.takeUpToWhere(_.converged)
 
   private def initialState(a: T, B: M, initX: T) = {
-    val r = a - mult(B, initX) - (initX :* normSquaredPenalty)
+    val r = a - mult(B, initX) - (initX *:* normSquaredPenalty)
     val d = copy(r)
     val rnorm = norm(r)
     State(initX, r, d, 0, rnorm <= tolerance)

--- a/math/src/main/scala/breeze/optimize/linear/InteriorPoint.scala
+++ b/math/src/main/scala/breeze/optimize/linear/InteriorPoint.scala
@@ -84,7 +84,7 @@ object InteriorPoint {
     val newC = DenseVector.zeros[Double](c.size + 1)
     newC(c.size) = 1
     val newX = DenseVector.tabulate(x0.size + 1)(i => if(i < x0.size) x0(i) else s)
-    if ( any((newA * newX - newB) :> 0.0) ) {
+    if ( any((newA * newX - newB) >:> 0.0) ) {
       throw new RuntimeException("Problem seems to be infeasible!")
     }
     val r = minimize(newA,newB,newC,newX)
@@ -100,7 +100,7 @@ object InteriorPoint {
   }
 
   private def computeAffineScalingDir(A: DenseMatrix[Double], b: DenseVector[Double], c: DenseVector[Double], x: DenseVector[Double], s: DenseVector[Double], z: DenseVector[Double]): (DenseVector[Double], DenseVector[Double], DenseVector[Double]) = {
-    val XiZ = diag(z :/ s)
+    val XiZ = diag(z /:/ s)
 
     val AtXiZ = (A.t * XiZ).asInstanceOf[DenseMatrix[Double]]
 
@@ -127,7 +127,7 @@ object InteriorPoint {
     diag(mat) += 1E-20
 
     val r = DenseVector.zeros[Double](m + n + m)
-    r.slice((m+n), (m+n+m)) -= (dsaff :* dzaff - sigma/m * (s dot z) )
+    r.slice((m+n), (m+n+m)) -= (dsaff *:* dzaff - sigma/m * (s dot z) )
     val sol = mat \ r
     (sol.slice(0, m),sol.slice(m, (n+m)),sol.slice((n+m), (n+m+m)))
   }

--- a/math/src/main/scala/breeze/optimize/proximal/NonlinearMinimizer.scala
+++ b/math/src/main/scala/breeze/optimize/proximal/NonlinearMinimizer.scala
@@ -166,7 +166,7 @@ object NonlinearMinimizer {
       val (f, g) = primal.calculate(x)
       val scale = x - z + u
       val proxObj = f + 0.5 * rho * pow(norm(scale), 2)
-      val proxGrad = g + scale :* rho
+      val proxGrad = g + scale *:* rho
       (proxObj, proxGrad)
     }
   }
@@ -239,7 +239,7 @@ object NonlinearMinimizer {
 
     val owlqn = new OWLQN[Int, DenseVector[Double]](-1, 10, lambdaL1, 1e-6)
 
-    val regularizedGram = h + (DenseMatrix.eye[Double](h.rows) :* lambdaL2)
+    val regularizedGram = h + (DenseMatrix.eye[Double](h.rows) *:* lambdaL2)
 
     val sparseQp = QuadraticMinimizer(h.rows, SPARSE, lambdaL1)
     val sparseQpStart = System.nanoTime()

--- a/math/src/main/scala/breeze/optimize/proximal/QpGenerator.scala
+++ b/math/src/main/scala/breeze/optimize/proximal/QpGenerator.scala
@@ -41,7 +41,7 @@ object QpGenerator {
     val q = DenseVector.rand[Double](nGram)
 
     val lb = zn.copy
-    val ub = en :* 10.0
+    val ub = en *:* 10.0
 
     val H = getGram(nGram)
 

--- a/math/src/main/scala/breeze/optimize/proximal/QuadraticMinimizer.scala
+++ b/math/src/main/scala/breeze/optimize/proximal/QuadraticMinimizer.scala
@@ -564,13 +564,13 @@ object QuadraticMinimizer {
     println(s"Test QuadraticMinimizer, CG , BFGS and OWLQN with $problemSize variables and $nequalities equality constraints")
     
     val luStart = System.nanoTime()
-    val luResult = h \ q:*(-1.0)
+    val luResult = h \ q *:* (-1.0)
     val luTime = System.nanoTime() - luStart
 
     val cg = new ConjugateGradient[DenseVector[Double], DenseMatrix[Double]]()
     
     val startCg = System.nanoTime()
-    val cgResult = cg.minimize(q:*(-1.0), h)
+    val cgResult = cg.minimize(q *:* (-1.0), h)
     val cgTime = System.nanoTime() - startCg
     
     val qpSolver = new QuadraticMinimizer(problemSize)
@@ -597,7 +597,7 @@ object QuadraticMinimizer {
     val lambdaL1 = lambda * beta
     val lambdaL2 = lambda * (1 - beta)
 
-    val regularizedGram = h + (DenseMatrix.eye[Double](h.rows) :* lambdaL2)
+    val regularizedGram = h + (DenseMatrix.eye[Double](h.rows) *:* lambdaL2)
     
     val sparseQp = QuadraticMinimizer(h.rows, SPARSE, lambdaL1)
     val sparseQpStart = System.nanoTime()

--- a/math/src/main/scala/breeze/signal/support/CanFirwin.scala
+++ b/math/src/main/scala/breeze/signal/support/CanFirwin.scala
@@ -91,8 +91,8 @@ object CanFirwin {
 
     val h = DenseVector.zeros[Double]( m.length )
     for(band <- scaledCutoff.toArray.zipWithIndex ) {
-      if( isEven(band._2) ) h -= sincpi(m :* band._1) :* band._1
-      else h += sincpi(m :* band._1) :* band._1
+      if( isEven(band._2) ) h -= sincpi(m *:* band._1) *:* band._1
+      else h += sincpi(m *:* band._1) *:* band._1
     }
 
     val win = optWindow match {
@@ -113,8 +113,8 @@ object CanFirwin {
         if(scaledCutoff(0) == 0d) 0d
         else if(scaledCutoff(1) == 1d) 1d
         else (scaledCutoff(0) + scaledCutoff(1))/2d
-      val c: DenseVector[Double] = cos( m :* (Pi * scaleFrequency) )
-      val s: Double = sum( h :* c )
+      val c: DenseVector[Double] = cos( m *:* (Pi * scaleFrequency) )
+      val s: Double = sum( h *:* c )
       h /= s
     }
 

--- a/math/src/main/scala/breeze/stats/distributions/Dirichlet.scala
+++ b/math/src/main/scala/breeze/stats/distributions/Dirichlet.scala
@@ -110,7 +110,7 @@ object Dirichlet {
 
     def mle(stats: SufficientStatistic) = {
       val likelihood = likelihoodFunction(stats)
-      val result = minimize(likelihood, zeroLike(stats.t) :+ 1.0)
+      val result = minimize(likelihood, zeroLike(stats.t) +:+ 1.0)
       result
     }
 


### PR DESCRIPTION
Fixes https://github.com/scalanlp/breeze/issues/521.

Some operators look pretty wild, like `>=:>=`. Maybe I should not do this for comparison operators? Though it's good to be consistent.

For exponentiation it makes things worse, since `^:^` has _lower_ precedence than even `:^`. But `:^` had pretty low precedence to begin with, so I think it's worth doing for consistency if you don't have a better idea.

Anyway, I'm very open to comments, as I just stared using Breeze and barely know what I'm doing. Thanks for considering this!