### PR TITLE
Consistent CanSlice2 Implicits

### DIFF
--- a/math/src/main/scala/breeze/linalg/SliceUtils.scala
+++ b/math/src/main/scala/breeze/linalg/SliceUtils.scala
@@ -1,0 +1,32 @@
+package breeze.linalg
+
+/**
+  * Utility class that handles negative row/column indicies and OOB checking
+  *
+  * @author Michael Petnuch
+  */
+private object SliceUtils {
+  def mapColumnSeq[V](cols: Seq[Int], nCols: Int) = cols match {
+    case range: Range => range.getRangeWithoutNegativeIndexes(nCols).map(col => mapColumn(col, nCols))
+    case _ => cols.map(col => mapColumn(col, nCols)).toIndexedSeq
+  }
+
+  def mapColumn[V](col: Int, nCols: Int) : Int = col match {
+    case oob  if col < -nCols => throw new ArrayIndexOutOfBoundsException("Column must be in bounds for slice!")
+    case oob  if col >= nCols => throw new ArrayIndexOutOfBoundsException("Column must be in bounds for slice!")
+    case neg  if col < 0      => neg + nCols
+    case _                    => col
+  }
+
+  def mapRowSeq[V](rows: Seq[Int], nRows: Int) = rows match {
+    case range: Range => range.getRangeWithoutNegativeIndexes(nRows).map(row => mapRow(row, nRows))
+    case _ => rows.map(row => mapRow(row, nRows)).toIndexedSeq
+  }
+
+  def mapRow[V](row: Int, nRows: Int) : Int = row match {
+    case oob  if row < -nRows => throw new ArrayIndexOutOfBoundsException("Row must be in bounds for slice!")
+    case oob  if row >= nRows => throw new ArrayIndexOutOfBoundsException("Row must be in bounds for slice!")
+    case neg  if row < 0      => neg + nRows
+    case _                    => row
+  }
+}

--- a/math/src/main/scala/breeze/linalg/SliceVector.scala
+++ b/math/src/main/scala/breeze/linalg/SliceVector.scala
@@ -120,6 +120,4 @@ object SliceVector {
       }
     }
   }
-
-
 }

--- a/math/src/main/scala/breeze/linalg/Tensor.scala
+++ b/math/src/main/scala/breeze/linalg/Tensor.scala
@@ -242,7 +242,6 @@ object Tensor {
 
   }
 
-
   implicit def canSliceTensor[K, V:ClassTag]:CanSlice[Tensor[K,V], Seq[K], SliceVector[K, V]] = new CanSlice[Tensor[K,V], Seq[K], SliceVector[K, V]] {
     def apply(from: Tensor[K, V], slice: Seq[K]): SliceVector[K, V] = new SliceVector(from, slice.toIndexedSeq)
   }
@@ -261,21 +260,19 @@ object Tensor {
     }
   }
 
-  implicit def canSliceTensor2_CRs[K1, K2, V:Semiring:ClassTag]:CanSlice2[Tensor[(K1,K2),V], Seq[K1], K2, SliceMatrix[K1, K2, V]] = {
-    new CanSlice2[Tensor[(K1,K2),V], Seq[K1], K2, SliceMatrix[K1, K2, V]] {
-      def apply(from: Tensor[(K1, K2), V], slice: Seq[K1], slice2: K2): SliceMatrix[K1, K2, V] = {
-        new SliceMatrix(from, slice.toIndexedSeq, IndexedSeq(slice2))
+  implicit def canSliceTensor2_CRs[K1, K2, V:Semiring:ClassTag]:CanSlice2[Tensor[(K1,K2),V], Seq[K1], K2, SliceVector[(K1, K2), V]] = {
+    new CanSlice2[Tensor[(K1,K2),V], Seq[K1], K2, SliceVector[(K1, K2), V]] {
+      def apply(from: Tensor[(K1, K2), V], slice: Seq[K1], slice2: K2): SliceVector[(K1, K2), V] = {
+        new SliceVector(from, slice.map(k1 => (k1, slice2)).toIndexedSeq)
       }
     }
   }
 
-  implicit def canSliceTensor2_CsR[K1, K2, V:Semiring:ClassTag]:CanSlice2[Tensor[(K1,K2),V], K1, Seq[K2], SliceMatrix[K1, K2, V]] = {
-    new CanSlice2[Tensor[(K1,K2),V], K1, Seq[K2], SliceMatrix[K1, K2, V]] {
-      def apply(from: Tensor[(K1, K2), V], slice: K1, slice2: Seq[K2]): SliceMatrix[K1, K2, V] = {
-        new SliceMatrix(from, IndexedSeq(slice), slice2.toIndexedSeq)
+  implicit def canSliceTensor2_CsR[K1, K2, V:Semiring:ClassTag]:CanSlice2[Tensor[(K1,K2),V], K1, Seq[K2], SliceVector[(K1, K2), V]] = {
+    new CanSlice2[Tensor[(K1,K2),V], K1, Seq[K2], SliceVector[(K1, K2), V]] {
+      def apply(from: Tensor[(K1, K2), V], slice: K1, slice2: Seq[K2]): SliceVector[(K1, K2), V] = {
+        new SliceVector(from, slice2.map(k2 => (slice, k2)).toIndexedSeq)
       }
     }
   }
-
 }
-

--- a/math/src/main/scala/breeze/linalg/Vector.scala
+++ b/math/src/main/scala/breeze/linalg/Vector.scala
@@ -39,8 +39,6 @@ trait VectorLike[@spec V, +Self <: Vector[V]] extends Tensor[Int, V] with Tensor
   def map[V2, That](fn: V=>V2)(implicit canMapValues: CanMapValues[Self  @uncheckedVariance, V, V2, That]):That = values map fn
 
   def foreach[U](fn: V=>U): Unit = { values foreach fn }
-
-  def copy: Self
 }
 
 
@@ -64,6 +62,7 @@ trait Vector[@spec(Int, Double, Float) V] extends VectorLike[V, Vector[V]]{
 
   def keysIterator = Iterator.range(0, size)
 
+  def copy: Vector[V]
 
   override def equals(p1: Any) = p1 match {
     case x: Vector[_] =>

--- a/math/src/main/scala/breeze/linalg/operators/DenseMatrixOps.scala
+++ b/math/src/main/scala/breeze/linalg/operators/DenseMatrixOps.scala
@@ -917,6 +917,62 @@ trait LowPriorityDenseMatrix extends LowPriorityDenseMatrix1 {
     }
   }
 
+  implicit def canSliceTensorBooleanRows[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], ::.type, SliceMatrix[Int, Int, V]] = {
+    new CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], ::.type, SliceMatrix[Int, Int, V]] {
+      def apply(from: DenseMatrix[V], rows: Tensor[Int, Boolean], cols: ::.type): SliceMatrix[Int, Int, V] = {
+        new SliceMatrix(from, rows.findAll(_ == true), (0 until from.cols))
+      }
+    }
+  }
+
+  implicit def canSliceTensorBooleanRowsAndCol[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Int, SliceVector[(Int, Int), V]] = {
+    new CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Int, SliceVector[(Int, Int), V]] {
+      def apply(from: DenseMatrix[V], rows: Tensor[Int, Boolean], col: Int): SliceVector[(Int, Int), V] = {
+        new SliceVector(from, rows.findAll(_ == true).map(row => (row, col)))
+      }
+    }
+  }
+
+  implicit def canSliceTensorBooleanCols[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], ::.type, Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] = {
+    new CanSlice2[DenseMatrix[V], ::.type, Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] {
+      def apply(from: DenseMatrix[V], rows: ::.type, cols: Tensor[Int, Boolean]): SliceMatrix[Int, Int, V] = {
+        new SliceMatrix(from, (0 until from.rows), cols.findAll(_ == true))
+      }
+    }
+  }
+
+  implicit def canSliceTensorRowAndBooleanCols[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], Int, Tensor[Int, Boolean], SliceVector[(Int, Int), V]] = {
+    new CanSlice2[DenseMatrix[V], Int, Tensor[Int, Boolean], SliceVector[(Int, Int), V]] {
+      def apply(from: DenseMatrix[V], row: Int, cols: Tensor[Int, Boolean]): SliceVector[(Int, Int), V] = {
+        new SliceVector(from, cols.findAll(_ == true).map(col => (row, col)))
+      }
+    }
+  }
+
+  implicit def canSliceTensorBooleanRowsAndCols[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] = {
+    new CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] {
+      def apply(from: DenseMatrix[V], rows: Tensor[Int, Boolean], cols: Tensor[Int, Boolean]): SliceMatrix[Int, Int, V] = {
+        new SliceMatrix(from, rows.findAll(_ == true), cols.findAll(_ == true))
+      }
+    }
+  }
+
+  implicit def canSliceTensorBooleanRowsAndWeirdCols[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Seq[Int], SliceMatrix[Int, Int, V]] = {
+    new CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Seq[Int], SliceMatrix[Int, Int, V]] {
+      def apply(from: DenseMatrix[V], rows: Tensor[Int, Boolean], cols: Seq[Int]): SliceMatrix[Int, Int, V] = {
+        new SliceMatrix(from, rows.findAll(_ == true), cols.toIndexedSeq)
+      }
+    }
+  }
+
+  implicit def canSliceWeirdRowsAndTensorBooleanCols[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], Seq[Int], Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] = {
+    new CanSlice2[DenseMatrix[V], Seq[Int], Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] {
+      def apply(from: DenseMatrix[V], rows: Seq[Int], cols: Tensor[Int, Boolean]): SliceMatrix[Int, Int, V] = {
+        new SliceMatrix(from, rows.toIndexedSeq, cols.findAll(_ == true))
+      }
+    }
+  }
+
   // <editor-fold defaultstate="collapsed" desc=" implicit implementations for OpSet ">
 
   class SetDMDMOp[@spec(Double, Int, Float, Long) V] extends OpSet.InPlaceImpl2[DenseMatrix[V], DenseMatrix[V]] {

--- a/math/src/main/scala/breeze/linalg/operators/DenseMatrixOps.scala
+++ b/math/src/main/scala/breeze/linalg/operators/DenseMatrixOps.scala
@@ -925,50 +925,10 @@ trait LowPriorityDenseMatrix extends LowPriorityDenseMatrix1 {
     }
   }
 
-  implicit def canSliceTensorBooleanRowsAndCol[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Int, SliceVector[(Int, Int), V]] = {
-    new CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Int, SliceVector[(Int, Int), V]] {
-      def apply(from: DenseMatrix[V], rows: Tensor[Int, Boolean], col: Int): SliceVector[(Int, Int), V] = {
-        new SliceVector(from, rows.findAll(_ == true).map(row => (row, col)))
-      }
-    }
-  }
-
   implicit def canSliceTensorBooleanCols[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], ::.type, Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] = {
     new CanSlice2[DenseMatrix[V], ::.type, Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] {
       def apply(from: DenseMatrix[V], rows: ::.type, cols: Tensor[Int, Boolean]): SliceMatrix[Int, Int, V] = {
         new SliceMatrix(from, (0 until from.rows), cols.findAll(_ == true))
-      }
-    }
-  }
-
-  implicit def canSliceTensorRowAndBooleanCols[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], Int, Tensor[Int, Boolean], SliceVector[(Int, Int), V]] = {
-    new CanSlice2[DenseMatrix[V], Int, Tensor[Int, Boolean], SliceVector[(Int, Int), V]] {
-      def apply(from: DenseMatrix[V], row: Int, cols: Tensor[Int, Boolean]): SliceVector[(Int, Int), V] = {
-        new SliceVector(from, cols.findAll(_ == true).map(col => (row, col)))
-      }
-    }
-  }
-
-  implicit def canSliceTensorBooleanRowsAndCols[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] = {
-    new CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] {
-      def apply(from: DenseMatrix[V], rows: Tensor[Int, Boolean], cols: Tensor[Int, Boolean]): SliceMatrix[Int, Int, V] = {
-        new SliceMatrix(from, rows.findAll(_ == true), cols.findAll(_ == true))
-      }
-    }
-  }
-
-  implicit def canSliceTensorBooleanRowsAndWeirdCols[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Seq[Int], SliceMatrix[Int, Int, V]] = {
-    new CanSlice2[DenseMatrix[V], Tensor[Int, Boolean], Seq[Int], SliceMatrix[Int, Int, V]] {
-      def apply(from: DenseMatrix[V], rows: Tensor[Int, Boolean], cols: Seq[Int]): SliceMatrix[Int, Int, V] = {
-        new SliceMatrix(from, rows.findAll(_ == true), cols.toIndexedSeq)
-      }
-    }
-  }
-
-  implicit def canSliceWeirdRowsAndTensorBooleanCols[V: Semiring : ClassTag]: CanSlice2[DenseMatrix[V], Seq[Int], Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] = {
-    new CanSlice2[DenseMatrix[V], Seq[Int], Tensor[Int, Boolean], SliceMatrix[Int, Int, V]] {
-      def apply(from: DenseMatrix[V], rows: Seq[Int], cols: Tensor[Int, Boolean]): SliceMatrix[Int, Int, V] = {
-        new SliceMatrix(from, rows.toIndexedSeq, cols.findAll(_ == true))
       }
     }
   }

--- a/math/src/test/scala/breeze/linalg/SliceMatrixTest.scala
+++ b/math/src/test/scala/breeze/linalg/SliceMatrixTest.scala
@@ -52,4 +52,26 @@ class SliceMatrixTest extends FunSuite {
     assert(expected.equals(a), "Failed to execute the addition on the slices")
   }
 
+  test("slices of a slice matrix") {
+    val a = DenseMatrix.tabulate[Int](5,5){ (i, j) => 5 * i + j + 1}
+
+    // first matrix with the 4th row and 3rd column removed
+    val b = a(Seq(0, 1, 2, 4), Seq(0, 1, 3, 4))
+
+    // check row slice
+    assert(b(1, ::) == DenseVector(6, 7, 9, 10), "Failed> b(1, ::) = " + b(1, ::))
+
+    // check column slice
+    assert(b(::, 1) == DenseVector(2, 7, 12, 22), "Failed> b(::, 1) = " + b(::, 1))
+
+    // check arb ro5w slice
+    assert(b(Seq(1, 3), ::) ==  DenseMatrix.create(2, 4,  Array(6, 7, 9, 10, 21, 22, 24, 25), 0, 4, true), "Failed> b(Seq(1, 3), ::) = " + b(Seq(1,3), ::))
+
+    // check arb col slice
+    assert(b(::, Seq(1, 3)) == DenseMatrix.create( 4, 2,  Array(2, 7, 12, 22, 5, 10, 15, 25), 0, 4, false), "Failed> b(::, Seq(1,3) = " + b(Seq(1, 3), ::))
+
+
+
+  }
+
  }

--- a/math/src/test/scala/breeze/linalg/SliceMatrixTest.scala
+++ b/math/src/test/scala/breeze/linalg/SliceMatrixTest.scala
@@ -7,8 +7,12 @@ import org.scalatest.FunSuite
   * @author dlwh
   */
 class SliceMatrixTest extends FunSuite {
+  val originalMatrix = DenseMatrix.tabulate[Int](5,5){ (i, j) => 5 * i + j + 1}
 
-   test("basic slices of a counter2") {
+  // first matrix with the 4th row and 3rd column removed
+  val sliceMatrix = originalMatrix(Seq(0, 1, 2, 4), Seq(0, 1, 3, 4))
+
+  test("basic slices of a counter2") {
      val ctr = Counter2( ('a,0, 1), ('b, 1, 10), ('a,1, 6))
      val v:Matrix[Int] = ctr(Seq('a, 'b), Seq(1, 0))
      assert(v(0,0) === ctr('a,1))
@@ -53,25 +57,63 @@ class SliceMatrixTest extends FunSuite {
   }
 
   test("slices of a slice matrix") {
-    val a = DenseMatrix.tabulate[Int](5,5){ (i, j) => 5 * i + j + 1}
-
-    // first matrix with the 4th row and 3rd column removed
-    val b = a(Seq(0, 1, 2, 4), Seq(0, 1, 3, 4))
-
     // check row slice
-    assert(b(1, ::) == DenseVector(6, 7, 9, 10), "Failed> b(1, ::) = " + b(1, ::))
+    assert(sliceMatrix(1, ::) == DenseVector(6, 7, 9, 10), "Failed> b(1, ::) = " + sliceMatrix(1, ::))
 
     // check column slice
-    assert(b(::, 1) == DenseVector(2, 7, 12, 22), "Failed> b(::, 1) = " + b(::, 1))
+    assert(sliceMatrix(::, 1) == DenseVector(2, 7, 12, 22), "Failed> b(::, 1) = " + sliceMatrix(::, 1))
 
-    // check arb ro5w slice
-    assert(b(Seq(1, 3), ::) ==  DenseMatrix.create(2, 4,  Array(6, 7, 9, 10, 21, 22, 24, 25), 0, 4, true), "Failed> b(Seq(1, 3), ::) = " + b(Seq(1,3), ::))
+    // check arb row slice
+    assert(sliceMatrix(Seq(1, 3), ::) == DenseMatrix.create(2, 4,  Array(6, 7, 9, 10, 21, 22, 24, 25), 0, 4, true), "Failed> b(Seq(1, 3), ::) = " + sliceMatrix(Seq(1,3), ::))
 
     // check arb col slice
-    assert(b(::, Seq(1, 3)) == DenseMatrix.create( 4, 2,  Array(2, 7, 12, 22, 5, 10, 15, 25), 0, 4, false), "Failed> b(::, Seq(1,3) = " + b(Seq(1, 3), ::))
-
-
-
+    assert(sliceMatrix(::, Seq(1, 3)) == DenseMatrix.create( 4, 2,  Array(2, 7, 12, 22, 5, 10, 15, 25), 0, 4, false), "Failed> b(::, Seq(1,3) = " + sliceMatrix(Seq(1, 3), ::))
   }
 
+  test("canSliceRow") {
+    assert(sliceMatrix(0, ::) == DenseVector( 1,  2,  4,  5), "Failed> sliceMatrix(0, ::) = " + sliceMatrix(0, ::))
+    assert(sliceMatrix(1, ::) == DenseVector( 6,  7,  9, 10), "Failed> sliceMatrix(1, ::) = " + sliceMatrix(1, ::))
+    assert(sliceMatrix(2, ::) == DenseVector(11, 12, 14, 15), "Failed> sliceMatrix(2, ::) = " + sliceMatrix(2, ::))
+    assert(sliceMatrix(3, ::) == DenseVector(21, 22, 24, 25), "Failed> sliceMatrix(3, ::) = " + sliceMatrix(3, ::))
+  }
+
+  test("canSliceRowAndWeirdCols") {
+    assert(sliceMatrix(0, Seq(0, 2)) == DenseVector( 1,  4), "Failed> sliceMatrix(0, ::) = " + sliceMatrix(0, Seq(0, 2)))
+    assert(sliceMatrix(1, Seq(0, 2)) == DenseVector( 6,  9), "Failed> sliceMatrix(1, ::) = " + sliceMatrix(1, Seq(0, 2)))
+    assert(sliceMatrix(2, Seq(0, 2)) == DenseVector(11,  14), "Failed> sliceMatrix(2, ::) = " + sliceMatrix(2, Seq(0, 2)))
+    assert(sliceMatrix(3, Seq(0, 2)) == DenseVector(21,  24), "Failed> sliceMatrix(3, ::) = " + sliceMatrix(3, Seq(0, 2)))
+  }
+
+  test("canSliceCol") {
+    assert(sliceMatrix(::, 0) == DenseVector( 1,  6, 11, 21), "Failed> sliceMatrix(::, 0) = " + sliceMatrix(::, 0))
+    assert(sliceMatrix(::, 1) == DenseVector( 2,  7, 12, 22), "Failed> sliceMatrix(::, 1) = " + sliceMatrix(::, 1))
+    assert(sliceMatrix(::, 2) == DenseVector( 4,  9, 14, 24), "Failed> sliceMatrix(::, 2) = " + sliceMatrix(::, 2))
+    assert(sliceMatrix(::, 3) == DenseVector( 5, 10, 15, 25), "Failed> sliceMatrix(::, 3) = " + sliceMatrix(::, 3))
+  }
+
+  test("canSliceWeirdRowsAndCol") {
+    assert(sliceMatrix(Seq(0, 2), 0) == DenseVector( 1, 11), "Failed> sliceMatrix(::, 0) = " + sliceMatrix(Seq(0, 2), 0))
+    assert(sliceMatrix(Seq(0, 2), 1) == DenseVector( 2, 12), "Failed> sliceMatrix(::, 1) = " + sliceMatrix(Seq(0, 2), 1))
+    assert(sliceMatrix(Seq(0, 2), 2) == DenseVector( 4, 14), "Failed> sliceMatrix(::, 2) = " + sliceMatrix(Seq(0, 2), 2))
+    assert(sliceMatrix(Seq(0, 2), 3) == DenseVector( 5, 15), "Failed> sliceMatrix(::, 3) = " + sliceMatrix(Seq(0, 2), 3))
+  }
+
+  test("canSliceTensorBoolean") {
+    val booleanTensor = BitVector(true, false, true, false)
+    assert(sliceMatrix(booleanTensor, ::) == DenseMatrix.create(2, 4, Array(1, 2, 4, 5, 11, 12, 14, 15), 0, 4, true))
+
+    assert(sliceMatrix(::, booleanTensor) == DenseMatrix.create(4, 2, Array(1, 6, 11, 21, 4, 9, 14, 24), 0, 4, false))
+
+    assert(sliceMatrix(booleanTensor, booleanTensor) == DenseMatrix.create(2, 2, Array(1, 4, 11, 14), 0, 2, true))
+
+    assert(sliceMatrix(booleanTensor, 0) == DenseVector(1, 11))
+    assert(sliceMatrix(booleanTensor, 1) == DenseVector(2, 12))
+    assert(sliceMatrix(booleanTensor, 2) == DenseVector(4, 14))
+    assert(sliceMatrix(booleanTensor, 3) == DenseVector(5, 15))
+
+    assert(sliceMatrix(0, booleanTensor) == DenseVector(1, 4))
+    assert(sliceMatrix(1, booleanTensor) == DenseVector(6, 9))
+    assert(sliceMatrix(2, booleanTensor) == DenseVector(11, 14))
+    assert(sliceMatrix(3, booleanTensor) == DenseVector(21, 24))
+  }
  }


### PR DESCRIPTION
Hi. I'm submitting a pull request to fix the following issues/inconsistencies we had while using breeze internally.

1. Create TensorBoolean Slice2 implicits to mirrors the Slice implicits available for a vector in Tensor. The rational behind adding these is the have a consistent slicing interface between vectors and matrices. If you are able to do the following with a vector:

```
val v = DenseVector.tabulate(10)(x => x)
v(v :> 5)
```

You should also be able to do something similar with a matrix
```
val m = DenseMatrix.tabulate(5, 5)((i,j) => 5 * i + j + 1)
val row2Slice = m(1, ::) :> 8
m(row2Slice.t, ::)
m(row2Slice.t, 1)
m(row2Slice.t, Seq(2, 3))
```

2. The same goes for SliceMatrix. Once you have a SpliceMatrix you really can't "slice" it further. Thus I created analogous implicits to operate on slice matrixes like you can on a regular dense matrix. You should have a consistent set of available slicing methods on Matrix objects so that you are not forced to always create a copy by converting the SliceMatrix to a DenseMatrix. You should have the choice to make the copy when operating on the dense matrix makes whatever operation you are doing faster.


Let me know if you have any issues and or comments with my commit. 

Thanks!

Michael Petnuch
