### PR TITLE
bug fix: assert that operations on different sized vectors fail. 

### DIFF
--- a/math/src/main/scala/breeze/linalg/operators/DenseVectorOps.scala
+++ b/math/src/main/scala/breeze/linalg/operators/DenseVectorOps.scala
@@ -149,6 +149,7 @@ trait DenseVectorOps extends DenseVector_GenericOps { this: DenseVector.type =>
   op: Op.Impl2[T, T, T]):Op.Impl2[DenseVector[T], DenseVector[T], DenseVector[T]] = {
     new Op.Impl2[DenseVector[T], DenseVector[T], DenseVector[T]] {
       def apply(a: DenseVector[T], b: DenseVector[T]): DenseVector[T] = {
+        require(a.length == b.length, "Lengths must match!")
         val ad = a.data
         val bd = b.data
         var aoff = a.offset
@@ -642,6 +643,7 @@ trait DenseVector_OrderingOps extends DenseVectorOps { this: DenseVector.type =>
   (implicit @expand.sequence[Op]({_ > _},  {_ >= _}, {_ <= _}, {_ < _}, { _ == _}, {_ != _})
   op: Op.Impl2[T, T, Boolean]):Op.Impl2[DenseVector[T], Vector[T], BitVector] = new Op.Impl2[DenseVector[T], Vector[T], BitVector] {
     def apply(a: DenseVector[T], b: Vector[T]): BitVector = {
+      require(a.length == b.length, "Vector lengths must match!")
       val ad = a.data
       var aoff = a.offset
       val result = BitVector.zeros(a.length)

--- a/math/src/test/scala/breeze/linalg/DenseVectorTest.scala
+++ b/math/src/test/scala/breeze/linalg/DenseVectorTest.scala
@@ -400,8 +400,29 @@ class DenseVectorTest extends FunSuite with Checkers {
       a(3)
       assert(false, "Shouldn't be here!")
     }
+  }
 
-
+  test("Vector <op> Vector should ensure vectors are same size") {
+    {
+      val a = Vector[Double](1D, 2D, 3D)
+      val b = Vector[Double](1D, 2D, 3D, 4D)
+      intercept[IllegalArgumentException] {
+        a + b
+      }
+      intercept[IllegalArgumentException] {
+        b + a
+      }
+    }
+    {
+      val a = Vector[Int](1, 2, 3)
+      val b = Vector[Int](1, 2, 3, 4)
+      intercept[IllegalArgumentException] {
+        a + b
+      }
+      intercept[IllegalArgumentException] {
+        b + a
+      }
+    }
   }
 
   test("Complex OpSet") {

--- a/math/src/test/scala/breeze/linalg/VectorTest.scala
+++ b/math/src/test/scala/breeze/linalg/VectorTest.scala
@@ -59,6 +59,17 @@ class VectorTest extends FunSuite {
     assert(max(v2) === 3)
   }
 
+  test("assert operations of different size fail") {
+    val a = Vector[Double](1D, 2D, 3D)
+    val b = Vector[Double](1D, 2D, 3D, 4D)
+    intercept[IllegalArgumentException] {
+      a + b
+    }
+    intercept[IllegalArgumentException] {
+      b + a
+    }
+  }
+
 }
 
 


### PR DESCRIPTION
In issue #515 I pointed out that the following bug exists:

```
scala> val a = DenseVector(1, 2, 3, 4, 5)
a: breeze.linalg.DenseVector[Int] = DenseVector(1, 2, 3, 4, 5)

scala> val b = DenseVector(1, 2, 3)
b: breeze.linalg.DenseVector[Int] = DenseVector(1, 2, 3)

scala> b + a
res71: breeze.linalg.DenseVector[Int] = DenseVector(2, 4, 6)

scala> a + b
java.lang.ArrayIndexOutOfBoundsException: 3
  at breeze.linalg.operators.DenseVectorOps$$anon$142.apply(DenseVectorOps.scala:161)
  at breeze.linalg.operators.DenseVectorOps$$anon$142.apply(DenseVectorOps.scala:150)
  at breeze.linalg.NumericOps$class.$plus(NumericOps.scala:172)
  at breeze.linalg.DenseVector.$plus(DenseVector.scala:51)
  ... 42 elided
```

In this PR, I added some assertions to ensure that both `a + b` and `b + a` will throw errors.  I also added a couple tests.  Please let me know whether I should make further changes, and thank you!