### PR TITLE
Allow construction of matrix from empty row sequence

### DIFF
--- a/math/src/main/scala/breeze/linalg/Matrix.scala
+++ b/math/src/main/scala/breeze/linalg/Matrix.scala
@@ -241,7 +241,10 @@ trait MatrixConstructors[Mat[T]<:Matrix[T]] {
   def apply[@specialized(/* Don't remove until SI-8886 is closed*/) R,
             @spec(Double, Int, Float, Long) V](rows : R*)(implicit rl : LiteralRow[R,V], man : ClassTag[V], zero: Zero[V]) = {
     val nRows = rows.length
-    val ns = rl.length(rows(0))
+    val ns = rows.headOption match {
+      case None => 0
+      case Some(firstRow) => rl.length(firstRow)
+    }
     val rv = zeros(nRows, ns)
     finishLiteral(rv, rl, rows)
     rv

--- a/math/src/test/scala/breeze/linalg/DenseMatrixTest.scala
+++ b/math/src/test/scala/breeze/linalg/DenseMatrixTest.scala
@@ -754,6 +754,12 @@ class DenseMatrixTest extends FunSuite with Checkers with Matchers with DoubleIm
     assert(m2 * v2 == DenseVector.zeros[Double](10))
   }
 
+  test("#534: DenseMatrix construction from empty row sequence") {
+    val rows = Seq.empty[Seq[Double]]
+    val matrix = DenseMatrix(rows: _*)
+    assert(matrix.rows == 0)
+    assert(matrix.cols == 0)
+  }
 
 
 }


### PR DESCRIPTION
This fixes scalanlp/breeze#534.