### PR TITLE
Consistent CanSlice2 for Row Slices of Matrix returning Transpose

### DIFF
--- a/math/src/main/scala/breeze/linalg/Matrix.scala
+++ b/math/src/main/scala/breeze/linalg/Matrix.scala
@@ -297,12 +297,12 @@ trait LowPriorityMatrix {
     }
   }
 
-  implicit def canSliceRowAndTensorBooleanCols[V: Semiring : ClassTag]: CanSlice2[Matrix[V], Int, Tensor[Int, Boolean], SliceVector[(Int, Int), V]] = {
-    new CanSlice2[Matrix[V], Int, Tensor[Int, Boolean], SliceVector[(Int, Int), V]] {
-      def apply(from: Matrix[V], sliceRow: Int, sliceCols: Tensor[Int, Boolean]): SliceVector[(Int, Int), V] = {
+  implicit def canSliceRowAndTensorBooleanCols[V: Semiring : ClassTag]: CanSlice2[Matrix[V], Int, Tensor[Int, Boolean], Transpose[SliceVector[(Int, Int), V]]] = {
+    new CanSlice2[Matrix[V], Int, Tensor[Int, Boolean], Transpose[SliceVector[(Int, Int), V]]] {
+      def apply(from: Matrix[V], sliceRow: Int, sliceCols: Tensor[Int, Boolean]): Transpose[SliceVector[(Int, Int), V]] = {
         val row = SliceUtils.mapRow(sliceRow, from.rows)
         val cols = SliceUtils.mapColumnSeq(sliceCols.findAll(_ == true), from.cols)
-        new SliceVector(from, slices = cols.map(col => (row, col)))
+        new SliceVector(from, slices = cols.map(col => (row, col))).t
       }
     }
   }

--- a/math/src/main/scala/breeze/linalg/SliceMatrix.scala
+++ b/math/src/main/scala/breeze/linalg/SliceMatrix.scala
@@ -136,12 +136,12 @@ object SliceMatrix extends LowPrioritySliceMatrix with SliceMatrixOps {
   }
 
   // slices
-  implicit def canSliceRow[V: Semiring : ClassTag]: CanSlice2[SliceMatrix[Int, Int, V], Int, ::.type, SliceVector[(Int, Int), V]] = {
-    new CanSlice2[SliceMatrix[Int, Int, V], Int, ::.type, SliceVector[(Int, Int), V]] {
-      def apply(from: SliceMatrix[Int, Int, V], sliceRow: Int, ignored: ::.type): SliceVector[(Int, Int), V] = {
+  implicit def canSliceRow[V: Semiring : ClassTag]: CanSlice2[SliceMatrix[Int, Int, V], Int, ::.type, Transpose[SliceVector[(Int, Int), V]]] = {
+    new CanSlice2[SliceMatrix[Int, Int, V], Int, ::.type, Transpose[SliceVector[(Int, Int), V]]] {
+      def apply(from: SliceMatrix[Int, Int, V], sliceRow: Int, ignored: ::.type): Transpose[SliceVector[(Int, Int), V]] = {
         val row = SliceUtils.mapRow(sliceRow, from.rows)
         val cols = 0 until from.cols
-        new SliceVector(from, cols.map(col => (row, col)))
+        new SliceVector(from, cols.map(col => (row, col))).t
       }
     }
   }

--- a/math/src/main/scala/breeze/linalg/Tensor.scala
+++ b/math/src/main/scala/breeze/linalg/Tensor.scala
@@ -268,10 +268,10 @@ object Tensor {
     }
   }
 
-  implicit def canSliceTensor2_CsR[K1, K2, V:Semiring:ClassTag]:CanSlice2[Tensor[(K1,K2),V], K1, Seq[K2], SliceVector[(K1, K2), V]] = {
-    new CanSlice2[Tensor[(K1,K2),V], K1, Seq[K2], SliceVector[(K1, K2), V]] {
-      def apply(from: Tensor[(K1, K2), V], slice: K1, slice2: Seq[K2]): SliceVector[(K1, K2), V] = {
-        new SliceVector(from, slice2.map(k2 => (slice, k2)).toIndexedSeq)
+  implicit def canSliceTensor2_CsR[K1, K2, V:Semiring:ClassTag]:CanSlice2[Tensor[(K1,K2),V], K1, Seq[K2], Transpose[SliceVector[(K1, K2), V]]] = {
+    new CanSlice2[Tensor[(K1,K2),V], K1, Seq[K2], Transpose[SliceVector[(K1, K2), V]]] {
+      def apply(from: Tensor[(K1, K2), V], slice: K1, slice2: Seq[K2]): Transpose[SliceVector[(K1, K2), V]] = {
+        new SliceVector(from, slice2.map(k2 => (slice, k2)).toIndexedSeq).t
       }
     }
   }

--- a/math/src/test/scala/breeze/linalg/SliceMatrixTest.scala
+++ b/math/src/test/scala/breeze/linalg/SliceMatrixTest.scala
@@ -58,7 +58,7 @@ class SliceMatrixTest extends FunSuite {
 
   test("slices of a slice matrix") {
     // check row slice
-    assert(sliceMatrix(1, ::) == DenseVector(6, 7, 9, 10), "Failed> b(1, ::) = " + sliceMatrix(1, ::))
+    assert(sliceMatrix(1, ::) == DenseVector(6, 7, 9, 10).t, "Failed> b(1, ::) = " + sliceMatrix(1, ::))
 
     // check column slice
     assert(sliceMatrix(::, 1) == DenseVector(2, 7, 12, 22), "Failed> b(::, 1) = " + sliceMatrix(::, 1))
@@ -71,17 +71,17 @@ class SliceMatrixTest extends FunSuite {
   }
 
   test("canSliceRow") {
-    assert(sliceMatrix(0, ::) == DenseVector( 1,  2,  4,  5), "Failed> sliceMatrix(0, ::) = " + sliceMatrix(0, ::))
-    assert(sliceMatrix(1, ::) == DenseVector( 6,  7,  9, 10), "Failed> sliceMatrix(1, ::) = " + sliceMatrix(1, ::))
-    assert(sliceMatrix(2, ::) == DenseVector(11, 12, 14, 15), "Failed> sliceMatrix(2, ::) = " + sliceMatrix(2, ::))
-    assert(sliceMatrix(3, ::) == DenseVector(21, 22, 24, 25), "Failed> sliceMatrix(3, ::) = " + sliceMatrix(3, ::))
+    assert(sliceMatrix(0, ::) == DenseVector( 1,  2,  4,  5).t, "Failed> sliceMatrix(0, ::) = " + sliceMatrix(0, ::))
+    assert(sliceMatrix(1, ::) == DenseVector( 6,  7,  9, 10).t, "Failed> sliceMatrix(1, ::) = " + sliceMatrix(1, ::))
+    assert(sliceMatrix(2, ::) == DenseVector(11, 12, 14, 15).t, "Failed> sliceMatrix(2, ::) = " + sliceMatrix(2, ::))
+    assert(sliceMatrix(3, ::) == DenseVector(21, 22, 24, 25).t, "Failed> sliceMatrix(3, ::) = " + sliceMatrix(3, ::))
   }
 
   test("canSliceRowAndWeirdCols") {
-    assert(sliceMatrix(0, Seq(0, 2)) == DenseVector( 1,  4), "Failed> sliceMatrix(0, ::) = " + sliceMatrix(0, Seq(0, 2)))
-    assert(sliceMatrix(1, Seq(0, 2)) == DenseVector( 6,  9), "Failed> sliceMatrix(1, ::) = " + sliceMatrix(1, Seq(0, 2)))
-    assert(sliceMatrix(2, Seq(0, 2)) == DenseVector(11,  14), "Failed> sliceMatrix(2, ::) = " + sliceMatrix(2, Seq(0, 2)))
-    assert(sliceMatrix(3, Seq(0, 2)) == DenseVector(21,  24), "Failed> sliceMatrix(3, ::) = " + sliceMatrix(3, Seq(0, 2)))
+    assert(sliceMatrix(0, Seq(0, 2)) == DenseVector( 1,  4).t, "Failed> sliceMatrix(0, ::) = " + sliceMatrix(0, Seq(0, 2)))
+    assert(sliceMatrix(1, Seq(0, 2)) == DenseVector( 6,  9).t, "Failed> sliceMatrix(1, ::) = " + sliceMatrix(1, Seq(0, 2)))
+    assert(sliceMatrix(2, Seq(0, 2)) == DenseVector(11,  14).t, "Failed> sliceMatrix(2, ::) = " + sliceMatrix(2, Seq(0, 2)))
+    assert(sliceMatrix(3, Seq(0, 2)) == DenseVector(21,  24).t, "Failed> sliceMatrix(3, ::) = " + sliceMatrix(3, Seq(0, 2)))
   }
 
   test("canSliceCol") {
@@ -111,9 +111,9 @@ class SliceMatrixTest extends FunSuite {
     assert(sliceMatrix(booleanTensor, 2) == DenseVector(4, 14))
     assert(sliceMatrix(booleanTensor, 3) == DenseVector(5, 15))
 
-    assert(sliceMatrix(0, booleanTensor) == DenseVector(1, 4))
-    assert(sliceMatrix(1, booleanTensor) == DenseVector(6, 9))
-    assert(sliceMatrix(2, booleanTensor) == DenseVector(11, 14))
-    assert(sliceMatrix(3, booleanTensor) == DenseVector(21, 24))
+    assert(sliceMatrix(0, booleanTensor) == DenseVector(1, 4).t)
+    assert(sliceMatrix(1, booleanTensor) == DenseVector(6, 9).t)
+    assert(sliceMatrix(2, booleanTensor) == DenseVector(11, 14).t)
+    assert(sliceMatrix(3, booleanTensor) == DenseVector(21, 24).t)
   }
  }


### PR DESCRIPTION
When I submitted my previous pull request I didn't have the row slices return transposed vectors. This fixes that and makes them all consistent.