### PR TITLE
Fix bug of argtopk applying to DenseVector and k == length of vector

### DIFF
--- a/math/src/main/scala/breeze/linalg/functions/argsort.scala
+++ b/math/src/main/scala/breeze/linalg/functions/argsort.scala
@@ -26,7 +26,7 @@ object argsort extends UFunc with LowPriorityArgSort {
 
 
 /**
- * Returns a sequence of keys sorted by value
+ * Returns the top k indices with maximum value
  *
  * @author dlwh
  **/
@@ -37,7 +37,9 @@ object argtopk extends UFunc with LowPriorityArgTopK {
       override def apply(v: DenseVector[T], k: Int): IndexedSeq[Int] = {
         implicit val orderingInt: Ordering[Int] = Ordering[T].on((x: Int) => v(x)).reverse
         val ints = VectorBuilder.range(v.length)
-        quickSelect.implFromOrdering[Int, collection.mutable.IndexedSeq[Int]].apply(ints:collection.mutable.IndexedSeq[Int], k)
+        if (k != 0) {
+          quickSelect.implFromOrdering[Int, collection.mutable.IndexedSeq[Int]].apply(ints:collection.mutable.IndexedSeq[Int], k - 1)
+        }
         ints.take(k)
       }
     }

--- a/math/src/test/scala/breeze/linalg/functions/argsortTest.scala
+++ b/math/src/test/scala/breeze/linalg/functions/argsortTest.scala
@@ -1,6 +1,6 @@
 package breeze.linalg.functions
 
-import breeze.linalg.{DenseVector, argsort}
+import breeze.linalg.{DenseVector, SparseVector, argsort, argtopk}
 import org.scalacheck.Prop
 import org.scalatest.FunSuite
 import org.scalatest.prop.Checkers
@@ -16,4 +16,21 @@ class argsortTest extends FunSuite with Checkers {
     })
   }
 
+}
+
+class argtopkTest extends FunSuite {
+
+  test("argtopk vector") {
+    val dv = DenseVector(2, 0, 3, 2, -1)
+    assert(argtopk(dv, 0) === Seq.empty)
+    assert(argtopk(dv, 1) === Seq(2))
+    assert(argtopk(dv, 3).toSet === Set(0, 2, 3))
+    assert(argtopk(dv, 5).toSet === Set(0, 1, 2, 3, 4))
+
+    val sv = SparseVector(5)(0 -> 2, 2-> 3, 3-> 2)
+    assert(argtopk(sv, 0) === Seq.empty)
+    assert(argtopk(sv, 1) === Seq(2))
+    assert(argtopk(sv, 3).toSet === Set(0, 2, 3))
+    assert(argtopk(sv, 5).toSet === Set(0, 1, 2, 3, 4))
+  }
 }


### PR DESCRIPTION
```argtopk``` failed when applying to ```DenseVector``` and ```k == length of vector```. See more detail about this bug at #561.
We speed up ```argtopk``` for ```DenseVector``` by ```quickSelect```, but the argument of ```quickSelect``` is the vector indices which start with 0 and end with length - 1. So k - 1 should be pass in rather than k. This PR fix this bug.