### PR TITLE
Fix the convergence check of L-BFGS-B.

### DIFF
--- a/math/src/main/scala/breeze/optimize/LBFGSB.scala
+++ b/math/src/main/scala/breeze/optimize/LBFGSB.scala
@@ -295,7 +295,7 @@ class LBFGSB(lowerBounds: DenseVector[Double],
 
 object LBFGSB {
   def defaultConvergenceCheck(lowerBounds: DenseVector[Double], upperBounds: DenseVector[Double], tolerance: Double, maxIter: Int) = {
-    bfgsbConvergenceTest(lowerBounds, upperBounds) || FirstOrderMinimizer.functionValuesConverged(tolerance) || FirstOrderMinimizer.maxIterationsReached(maxIter)
+    bfgsbConvergenceTest(lowerBounds, upperBounds) || FirstOrderMinimizer.defaultConvergenceCheck(maxIter, tolerance)
   }
 
   protected val PROJ_GRADIENT_EPS = 1E-5


### PR DESCRIPTION
If there is ```searchFailed``` during optimization by ```L-BFGS-B```, it should be terminated rather than calling in an endless loop. The convergence check of ```L-BFGS-B``` does not handle ```searchFailed``` and ```gradientConverged``` currently. Since ```L-BFGS-B``` extends from ```FirstOrderMinimizer```, so my fix is let it call ```FirstOrderMinimizer.defaultConvergenceCheck``` to handle convergence check.