### PR TITLE
Modify shuffle.scala and add shuffleTest.scala

### DIFF
--- a/math/src/main/scala/breeze/linalg/functions/shuffle.scala
+++ b/math/src/main/scala/breeze/linalg/functions/shuffle.scala
@@ -1,64 +1,145 @@
 package breeze.linalg
 
 import breeze.generic.UFunc
-import breeze.macros.expand
-import spire.math.Complex
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 import breeze.stats.distributions.Rand
 
-/**Returns the given DenseVector, Array, or DenseMatrix as a shuffled copy. (Fisher-Yates shuffle)
+/**
+  * Return the given DenseVector, Array, or DenseMatrix as a shuffled copy
+  * by using Fisher-Yates shuffle.
+  * Additionally, can return the given Array as a shuffled copy with the
+  * corresponding shuffle index information, or return the given Array as a
+  * shuffled copy using the inverse of the given shuffle index information,
+  * reversing the shuffle.
+  *
   * @author ktakagaki
-  * @date 05/12/2014.
+  * @date 05/12/2014
+  * @author huaminli
+  * @date 08/01/2016
   */
 object shuffle extends UFunc {
 
-  implicit def implShuffle_Arr_eq_Arr[T](implicit ct: ClassTag[T]): Impl[Array[T], Array[T]] = {
+  implicit def implShuffle_Arr_eq_Arr[T](implicit ct: ClassTag[T]):
+  Impl[Array[T], Array[T]] = {
     new Impl[Array[T], Array[T]] {
-
+      /**
+        * Shuffle the given [[Array[T]]].
+        *
+        * @param arr the given array stored as [[Array[T]]]
+        * @return a shuffled array stored as [[Array[T]]]
+        */
       def apply(arr: Array[T]): Array[T] = {
+        // Make a copy of the input.
         val tempret = arr.clone()
-        val rand = Rand.randInt(tempret.length)
 
-        var count = 0
-        while(count < tempret.length) {
-          swap(tempret, count, rand.get())
-          count += 1
+        // Shuffle tempret via Fisher-Yates method.
+        var count = tempret.length - 1
+        while(count > 0) {
+          swap(tempret, count, Rand.randInt(count + 1).get())
+          count -= 1
         }
         tempret
       }
 
-      def swap(arr: Array[T], indexA: Int, indexB: Int): Unit = {
+      /**
+        * Swap two elements of [[Array[T]]] with specified indices [[Int]]
+        * @param arr the given array stored as [[Array[T]]]
+        * @param indexA the first given [[Int]] index
+        * @param indexB the second given [[Int]] index
+        */
+      def swap[T](arr: Array[T], indexA: Int, indexB: Int): Unit = {
         val temp = arr(indexA)
         arr(indexA) = arr(indexB)
         arr(indexB) = temp
       }
-
     }
   }
 
+  implicit def implShuffle_Arr_Arr_Int_eq_Arr[T](implicit ct: ClassTag[T]):
+  Impl3[Array[T], Array[Int], Int, Array[T]] = {
+    new Impl3[Array[T], Array[Int], Int, Array[T]] {
+      /**
+        * shuffle the given [[Array[T]]] according to the given
+        * permutation [[Array[Int]]] if [[Int]] indicator is zero;
+        * shuffle the given [[Array[T]]] according to the inverse of the given
+        * permutation [[Array[Int]]] if [[Int]] indicator is nonzero.
+        * @param arr the given array stored as [[Array[T]]]
+        * @param arrIndex the given permutation array stored as [[Array[Int]]]
+        * @param isInverse the indicator whether perform inverse shuffle
+        * @return a shuffled array stored as [[Array[T]]]
+        */
+      def apply(arr: Array[T], arrIndex: Array[Int],
+                isInverse: Int): Array[T] = {
+        require(arr.length == arrIndex.length,
+          "The two input arrays should have the same length!")
+        // Make a copy of the input.
+        val tempret = new Array[T](arr.length)
 
+        if (isInverse == 0) {
+          // Shuffle tempret via given permutation.
+          for (i <- arr.indices) {
+            tempret(i) = arr(arrIndex(i))
+          }
+        } else {
+          // Inverse shuffle tempret via given permutation.
+          for (i <- arr.indices) {
+            tempret(arrIndex(i)) = arr(i)
+          }
+        }
+        tempret
+      }
+    }
+  }
 
-  implicit def implShuffle_Coll_eq_Coll[Coll, T, CollRes](implicit view: Coll <:< IndexedSeq[T],
-                                                          cbf: CanBuildFrom[Coll, T, CollRes]) : Impl[Coll, CollRes] = {
+  implicit def implShuffle_Arr_Arr_eq_Arr[T](implicit ct: ClassTag[T]):
+  Impl2[Array[T], Array[Int], Array[T]] = {
+    new Impl2[Array[T], Array[Int], Array[T]] {
+      /**
+        * Shuffle the given [[Array[T]] according to the given
+        * permutation [[Array[Int]]].
+        * @param arr the given array stored as [[Array[T]]]
+        * @param arrIndex the given permutation array stored as [[Array[Int]]]
+        * @return a shuffled array stored as [[Array[T]]]
+        */
+      def apply(arr: Array[T], arrIndex: Array[Int]): Array[T] = {
+        // Shuffle the input via given permutation.
+        shuffle(arr, arrIndex, 0)
+      }
+    }
+  }
+
+  implicit def implShuffle_Coll_eq_Coll[Coll, T, CollRes](implicit view:
+  Coll <:< IndexedSeq[T], cbf: CanBuildFrom[Coll, T, CollRes]) :
+  Impl[Coll, CollRes] = {
     new Impl[Coll, CollRes] {
-
+      /**
+        * Shuffle the given [[Coll]].
+        * @param v the given collection stored as [[Coll]]
+        * @return a shuffled collection stored as [[CollRes]]
+        */
       override def apply(v: Coll): CollRes = {
+        // Make a copy of the input.
         val builder = cbf(v)
         val copy = v.to[ArrayBuffer]
-        val rand = Rand.randInt(copy.length)
 
-        var count = 0
-        while (count < copy.length) {
-          swap(copy, count, rand.get())
-          count += 1
+        // Shuffle tempret via Fisher-Yates method.
+        var count = copy.length - 1
+        while (count > 0) {
+          swap(copy, count, Rand.randInt(count + 1).get())
+          count -= 1
         }
-
         builder ++= copy
         builder.result()
       }
 
+      /**
+        * Swap two elements of [[Coll]] with specified indices [[Int]].
+        * @param arr the given array stored as [[Array[T]]]
+        * @param indexA the first given [[Int]] index
+        * @param indexB the second given [[Int]] index
+        */
       def swap(arr: ArrayBuffer[T], indexA: Int, indexB: Int): Unit = {
         val temp = arr(indexA)
         arr(indexA) = arr(indexB)
@@ -68,25 +149,36 @@ object shuffle extends UFunc {
     }
   }
 
-  implicit def implShuffle_DV_eq_DV[T](implicit arrImpl: Impl[Array[T], Array[T]],
-                                       ct: ClassTag[T]): Impl[DenseVector[T], DenseVector[T]] = {
+  implicit def implShuffle_DV_eq_DV[T](implicit arrImpl:
+  Impl[Array[T], Array[T]], ct: ClassTag[T]):
+  Impl[DenseVector[T], DenseVector[T]] = {
     new Impl[DenseVector[T], DenseVector[T]] {
-      def apply(dv: DenseVector[T]): DenseVector[T] = DenseVector(shuffle(dv.toArray))
+      /**
+        * Shuffle the given [[DenseVector[T]]].
+        * @param dv the given vector stored as [[DenseVector[T]]]
+        * @return a shuffled vector stored as [[DenseVector[T]]]
+        */
+      def apply(dv: DenseVector[T]): DenseVector[T] =
+        // convert to array and perform the shuffling.
+        new DenseVector(shuffle(dv.toArray))
     }
   }
 
-
-  implicit def implShuffle_DM_eq_DM[T](implicit arrImpl: Impl[Array[T], Array[T]],
-                                       ct: ClassTag[T]): Impl[DenseMatrix[T], DenseMatrix[T]] = {
+  implicit def implShuffle_DM_eq_DM[T](implicit arrImpl:
+  Impl[Array[T], Array[T]], ct: ClassTag[T]):
+  Impl[DenseMatrix[T], DenseMatrix[T]] = {
     new Impl[DenseMatrix[T], DenseMatrix[T]] {
-
+      /**
+        * Shuffle the given [[DenseMatrix[T]]].
+        * @param dm the given matrix stored as [[DenseMatrix[T]]]
+        * @return a shuffled matrix stored as [[DenseMatrix[T]]]
+        */
       def apply(dm: DenseMatrix[T]): DenseMatrix[T] = {
+        // convert to array and perform the shuffling.
         val rows = dm.rows
         val cols = dm.cols
         new DenseMatrix(rows, cols, shuffle(dm.toArray))
       }
     }
   }
-
-
 }

--- a/math/src/main/scala/breeze/linalg/functions/shuffle.scala
+++ b/math/src/main/scala/breeze/linalg/functions/shuffle.scala
@@ -57,9 +57,9 @@ object shuffle extends UFunc {
     }
   }
 
-  implicit def implShuffle_Arr_Arr_Int_eq_Arr[T](implicit ct: ClassTag[T]):
-  Impl3[Array[T], Array[Int], Int, Array[T]] = {
-    new Impl3[Array[T], Array[Int], Int, Array[T]] {
+  implicit def implShuffle_Arr_Arr_Boolean_eq_Arr[T](implicit ct: ClassTag[T]):
+  Impl3[Array[T], Array[Int], Boolean, Array[T]] = {
+    new Impl3[Array[T], Array[Int], Boolean, Array[T]] {
       /**
         * shuffle the given [[Array[T]]] according to the given
         * permutation [[Array[Int]]] if [[Int]] indicator is zero;
@@ -71,13 +71,13 @@ object shuffle extends UFunc {
         * @return a shuffled array stored as [[Array[T]]]
         */
       def apply(arr: Array[T], arrIndex: Array[Int],
-                isInverse: Int): Array[T] = {
+                isInverse: Boolean): Array[T] = {
         require(arr.length == arrIndex.length,
           "The two input arrays should have the same length!")
         // Make a copy of the input.
         val tempret = new Array[T](arr.length)
 
-        if (isInverse == 0) {
+        if (!isInverse) {
           // Shuffle tempret via given permutation.
           for (i <- arr.indices) {
             tempret(i) = arr(arrIndex(i))
@@ -105,7 +105,7 @@ object shuffle extends UFunc {
         */
       def apply(arr: Array[T], arrIndex: Array[Int]): Array[T] = {
         // Shuffle the input via given permutation.
-        shuffle(arr, arrIndex, 0)
+        shuffle(arr, arrIndex, false)
       }
     }
   }

--- a/math/src/test/scala/breeze/linalg/functions/shuffleTest.scala
+++ b/math/src/test/scala/breeze/linalg/functions/shuffleTest.scala
@@ -39,10 +39,11 @@ class shuffleTest extends FunSuite with Matchers{
     // shuffles randomly
     val result1 = shuffle(testArr, testIndex)
     // also shuffles randomly
-    val result2 = shuffle(testArr, testIndex, 0)
+    val result2 = shuffle(testArr, testIndex, false)
     // inverse shuffles
-    val result3 = shuffle(result2, testIndex, 1)
+    val result3 = shuffle(result2, testIndex, true)
     assert(result1 sameElements result2)
     assert(testArr sameElements result3)
   }
+
 }

--- a/math/src/test/scala/breeze/linalg/functions/shuffleTest.scala
+++ b/math/src/test/scala/breeze/linalg/functions/shuffleTest.scala
@@ -45,5 +45,4 @@ class shuffleTest extends FunSuite with Matchers{
     assert(result1 sameElements result2)
     assert(testArr sameElements result3)
   }
-
 }

--- a/math/src/test/scala/breeze/linalg/functions/shuffleTest.scala
+++ b/math/src/test/scala/breeze/linalg/functions/shuffleTest.scala
@@ -1,0 +1,49 @@
+package breeze.linalg.functions
+
+import org.scalatest._
+import breeze.linalg._
+import breeze.stats.hist
+
+import scala.util.Random
+
+/**
+  * Created by huaminli on 7/25/16.
+  */
+class shuffleTest extends FunSuite with Matchers{
+  test("The shuffle is uniformly random") {
+    // Create a histogram to record the first entry of array that has been
+    // shuffled many times.
+    val n = 10
+    val m = 100000
+    val testArray = Array.tabulate(n)(i => i + 1)
+    val histCount = DenseVector.zeros[Int](m)
+
+    for (i <- 0 until m) {
+      val shuffleArray = shuffle(testArray)
+      histCount(i) = shuffleArray(0)
+    }
+    // The frequency for each number to show up in the first entry
+    // should be close within some tolerance.
+    val result = hist(histCount, n)
+    for (i <- 0 until n) {
+      result.hist(i) should ===(m / n +- Math.sqrt(m).toInt)
+    }
+  }
+  test("Shuffle and shuffle back") {
+    // Shuffle array testArr at random,
+    // and should be able to shuffle it back to its original state.
+    val n = 10
+    val testIndex = shuffle(Array.tabulate(n)(i => i))
+    val testArr = Array.fill[Double](n) {Random.nextGaussian()}
+
+    // shuffles randomly
+    val result1 = shuffle(testArr, testIndex)
+    // also shuffles randomly
+    val result2 = shuffle(testArr, testIndex, 0)
+    // inverse shuffles
+    val result3 = shuffle(result2, testIndex, 1)
+    assert(result1 sameElements result2)
+    assert(testArr sameElements result3)
+  }
+
+}


### PR DESCRIPTION
The original `shuffle.scala` was supposed to implement the [Fisher–Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle). Unfortunately, there was a bug that prevented the code from producing uniformly distributed permutations (whereas the purpose of the Fisher-Yates shuffle is to produce uniformly distributed permutations). The attached file, [TestShuffle.zip](https://github.com/scalanlp/breeze/files/394972/TestShuffle.zip), runs a quick test that demonstrates the problem; the test creates an array of integers from 1 to 10, shuffles the array 100,000 times, and creates a histogram to record the first entry of the integer array. If the shuffling is uniformly distributed, each number should appear roughly 100,000/10 = 10,000 times within certain ranges. 

The output from the previously committed code is:
`DenseVector(10073, 12883, 12008, 11144, 10389, 9861, 8983, 8618, 8256, 7785)`
The output from the new code is:
`DenseVector(10023, 10022, 10022, 10001, 10025, 10032, 10061, 10065, 9837, 9912)`
There are ten entries of the output array; each of them represents the number of times each of the ten numbers has appeared in the first entry of the shuffled array. If the shuffle is uniformly random, then each of these should be close to 10,000 within a few standard deviations (the standard deviation is sqrt(100,000) = 316.2). The second and third entries of the output array from the previously committed code are certainly far outside of a few standard deviations, whereas the output from the new codes produces reasonable results.

We fix the bug and add an additional feature to the committed `shuffle.scala` code: the new code can return the given Array as a shuffled copy with the corresponding shuffle index information, or return the given Array as a shuffled copy using the inverse of the given shuffle index information, reversing the shuffle. Furthermore, we add a unit test via the file `shuffleTest.scala` in the directory `breeze/math/src/test/scala/breeze/linalg/functions` to test that the shuffle is uniformly random (as above); the unit test also shuffles forward and back to test the new features as well.


