### PR TITLE
use local instance randInt to utilize provided generator

### DIFF
--- a/math/src/main/scala/breeze/stats/distributions/Rand.scala
+++ b/math/src/main/scala/breeze/stats/distributions/Rand.scala
@@ -199,7 +199,7 @@ class RandBasis(val generator: RandomGenerator) extends Serializable {
     }
   }
 
-  def choose[T](c : Seq[T]) = Rand.randInt(c.size).map( c(_))
+  def choose[T](c : Seq[T]) = randInt(c.size).map( c(_))
 
   /**
    * The trivial random generator: always returns the argument

--- a/math/src/test/scala/breeze/stats/distributions/RandTest.scala
+++ b/math/src/test/scala/breeze/stats/distributions/RandTest.scala
@@ -62,4 +62,21 @@ class RandTest extends FunSuite {
     }
   }
 
+  test("RandBasis.choose honors specified random seed") {
+    val items = 'a' to 'z'
+
+    {
+      val a = RandBasis.withSeed(0).choose(items).sample(100)
+      val b = RandBasis.withSeed(0).choose(items).sample(100)
+      assert(a == b)
+    }
+
+    {
+      val items = 'a' to 'z'
+      val a = RandBasis.withSeed(0).choose(items).sample(100)
+      val b = RandBasis.withSeed(1).choose(items).sample(100)
+      assert(a != b)
+    }
+  }
+
 }


### PR DESCRIPTION
The `RandInt.choose` method did not use the instance provided `generator`, but instead used the Rand object.  This causes a call to `myRandBasis.choose` to create a `Rand` that doesn't use the instances random stream.