### PR TITLE
Add capability to perform basic symbolic computations

### DIFF
--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -14,5 +14,8 @@ libraryDependencies := {
 
 libraryDependencies += "org.scala-lang" % "scala-reflect" % s"${scalaVersion.value}"
 
+libraryDependencies += "org.appdapter" % "ext.bundle.math.symja_jas" % "1.2.3" excludeAll(ExclusionRule(organization = "org.apache.log4j"))
+libraryDependencies += "log4j" % "log4j" % "1.2.17"
+
 addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full)
 

--- a/macros/src/main/scala/breeze/macros/symbolic/FunctionTransformationMacros.scala
+++ b/macros/src/main/scala/breeze/macros/symbolic/FunctionTransformationMacros.scala
@@ -1,0 +1,283 @@
+package breeze.macros.symbolic
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+import scala.collection.JavaConverters._
+import org.matheclipse.core.expression._
+import F.{Map => _, List => _, _}
+import org.matheclipse.core.interfaces.IExpr
+import org.matheclipse.core.eval.EvalEngine
+import org.matheclipse.core.interfaces.{ISymbol => SymjaSymbol}
+import org.matheclipse.core.expression.{Symbol => SymjaSymbolImpl}
+import org.matheclipse.core.generic.Functors
+
+import scala.util.Random
+/**
+  * Contains macros that transform SymbolicFunctions to an AST of the
+  * computational algebra library Symja, perform derivation / simplification
+  * in Symja and convert the result back to SymbolicFunctions.
+  * Used by CanDerive and CanSimplify to create implicit typeclass instances.
+  */
+class FunctionTransformationMacros(val c: whitebox.Context) {
+
+  F.initSymbols()
+
+  import c.mirror.universe._
+
+  private lazy val HListConsClassSymbol = c.mirror.staticClass("shapeless.$colon$colon")
+  private lazy val HNilClassSymbol = c.mirror.staticClass("shapeless.HNil")
+  private lazy val evalEngine = new EvalEngine()
+  private case class ValueAndType(value: Tree, tpe: Tree)
+  object Extractors {
+    case class Extractor[O](pf: PartialFunction[IExpr, O]) {
+      def unapply(i: IExpr): Option[O] = pf.lift.apply(i)
+    }
+
+    case class SeqExtractor[O](pf: PartialFunction[IExpr, Seq[O]]) {
+      def unapplySeq(i: IExpr): Option[Seq[O]] = pf.lift.apply(i)
+    }
+
+    val Times = SeqExtractor[IExpr] { case e if e.isTimes => e.leaves.asScala }
+    val Plus = SeqExtractor[IExpr] { case e if e.isPlus => e.leaves.asScala }
+    val Exponential = Extractor[IExpr] { case e if e.isPower && e.getAt(1).equals(F.E) => e.getAt(2) }
+    val Power = Extractor[(IExpr, IExpr)] { case e if e.isPower => (e.getAt(1), e.getAt(2)) }
+    val Logarithm = Extractor[IExpr] { case e if e.isLog => e.getAt(1) }
+    val Symbol = Extractor[SymjaSymbol] { case e if e.isSymbol => e.asInstanceOf[SymjaSymbol] }
+    val ConstInt = Extractor[Double] { case e if e.isInteger => e.asInstanceOf[IntegerSym].doubleValue() }
+    val Derivation = Extractor[IExpr] { case e if e.isAST("D", 3) => e.getAt(1).getAt(0) }
+    val Numeric = Extractor[Double] { case e if e.isNumeric => e.asInstanceOf[Num].doubleValue() }
+    val Function = Extractor[SymjaSymbol] {
+      case e: AST if e.head().asInstanceOf[SymjaSymbolImpl].getSymbol.startsWith("fun") => e.head().asInstanceOf[SymjaSymbol]
+    }
+  }
+
+  case class SymbolFunction(name: String) {
+    def unapply(sym: Symbol): Option[Symbol] =
+      if (sym == c.mirror.staticClass(s"breeze.symbolic.$name"))
+        Some(sym)
+      else
+        None
+  }
+
+  val ExponentialFunc = SymbolFunction("Exponential")
+  val PowerFunc = SymbolFunction("Power")
+  val LogarithmFunc = SymbolFunction("Logarithm")
+  val SumFunc = SymbolFunction("Sum")
+  val DifferenceFunc = SymbolFunction("Difference")
+  val ProductFunc = SymbolFunction("Product")
+  val DivisionFunc = SymbolFunction("Division")
+  val ConstOneFunc = SymbolFunction("ConstOne")
+  val ConstFunc = SymbolFunction("Const")
+  val NamedVarFunc = SymbolFunction("NamedVar")
+  val VarFunc = SymbolFunction("Var")
+  val ChainFunc = SymbolFunction("Chain")
+
+  private case class SymjaExprWithSymbolTable(symjaExpr: IExpr, symbolTable: Map[SymjaSymbol, (Type, List[String])]) {
+
+    def withExpression(expr: IExpr) = copy(symjaExpr = expr)
+
+    def withMappedExpression(wrapFn: IExpr => IExpr) = withExpression(wrapFn(symjaExpr))
+
+    def withPrependedPath(path: String): SymjaExprWithSymbolTable =
+      copy(symbolTable = symbolTable.mapValues { case (t, l) => (t, path :: l) })
+
+    def mergeWith(otherExpr: SymjaExprWithSymbolTable, combiner: (IExpr, IExpr) => IExpr): SymjaExprWithSymbolTable =
+      copy(symjaExpr = combiner(symjaExpr, otherExpr.symjaExpr), symbolTable = symbolTable ++ otherExpr.symbolTable)
+
+    def pathAndTypeOfExpression: Option[(Type, List[String])] = symjaExpr match {
+      case s: SymjaSymbol => symbolTable.get(s)
+      case a: AST if a.head().isSymbol => symbolTable.get(a.head().asInstanceOf[SymjaSymbol])
+      case _ => None
+    }
+  }
+
+  private object CasFunction {
+    def unapplySeq(typeArgs: List[Type]): Option[List[SymjaExprWithSymbolTable]] =
+      Some(typeArgs.map(ta => toCasFunction(ta)))
+  }
+
+  val defaultFunctionArgument: SymjaSymbol = F.x
+
+  private def toCasFunction(inner: Type): SymjaExprWithSymbolTable =
+    inner.dealias match {
+      case TypeRef(pre, sym, args) => {
+        (sym, args) match {
+          case (ExponentialFunc(_), CasFunction(symjaExprWithSymbolTable)) =>
+            symjaExprWithSymbolTable.withPrependedPath("fn").withMappedExpression(Exp(_))
+
+          case (PowerFunc(_), Seq(base, exponent)) => {
+            val expCas = toCasFunction(exponent).withPrependedPath("exp")
+            toCasFunction(base).withPrependedPath("fn").mergeWith(expCas, (base, exp) => Power(base, exp))
+          }
+
+          case (LogarithmFunc(_), CasFunction(symjaExprWithSymbolTable)) =>
+            symjaExprWithSymbolTable.withPrependedPath("fn").withMappedExpression(Log(_))
+
+          case (SumFunc(_), Seq(funcHList)) =>
+            extractHList(funcHList).reduce { (symA, symB) =>
+              symA.mergeWith(symB, _ plus _)
+            }.withPrependedPath("fns")
+
+          case (DifferenceFunc(_), CasFunction(numerator, denominator)) =>
+            numerator.withPrependedPath("fn1").mergeWith(denominator.withPrependedPath("fn2"), _ minus _)
+
+          case (ProductFunc(_), Seq(funcHList)) =>
+            extractHList(funcHList).reduce { (symA, symB) =>
+              symA.mergeWith(symB, _ times _)
+            }.withPrependedPath("fns")
+
+          case (DivisionFunc(_), CasFunction(numerator, denominator)) =>
+            numerator.withPrependedPath("fn1").mergeWith(denominator.withPrependedPath("fn2"), _ divide  _)
+
+          case (ConstOneFunc(_), Seq()) =>
+            SymjaExprWithSymbolTable(Num.valueOf(1.0), Map())
+
+          case (ConstFunc(_), Seq(innerType)) => {
+            val variable = new SymjaSymbolImpl("var" + Random.nextLong.abs.toString)
+            SymjaExprWithSymbolTable(variable, Map(variable -> (inner, List())))
+          }
+
+          case (NamedVarFunc(_), Seq(innerType)) => {
+            val varName = innerType match {
+              case TypeRef(SingleType(_, sym), _, _) => sym.name.toString
+              case RefinedType(bar, _) =>
+                val List(_, TypeRef(_, _, List(constant))) = bar
+                val ConstantType(Constant(sym)) = constant
+                sym.toString
+            }
+            val variable = new SymjaSymbolImpl(varName)
+            SymjaExprWithSymbolTable(variable, Map(variable -> (inner, List())))
+          }
+
+          case (VarFunc(_), Seq()) =>
+            SymjaExprWithSymbolTable(defaultFunctionArgument, Map(defaultFunctionArgument -> (inner, List[String]())))
+
+          case (ChainFunc(_), CasFunction(outerFunc, innerFunc)) =>
+            outerFunc.withPrependedPath("outer").mergeWith(innerFunc.withPrependedPath("inner"), (o, i) => F.subst(o, Functors.rules(Rule(defaultFunctionArgument, i))))
+          case _ =>
+            val functionName = F.local(s"fun${inner.hashCode}")
+            SymjaExprWithSymbolTable(F.unary(functionName, defaultFunctionArgument), Map(functionName -> (inner, List())))
+        }
+      }
+      case x => c.abort(c.enclosingPosition, s"Got something else\n$inner")
+    }
+
+  private def extractHList(hlistType: Type): List[SymjaExprWithSymbolTable] = {
+    hlistType.dealias match {
+      case TypeRef(_, sym, _) if sym == HNilClassSymbol => Nil
+      case TypeRef(_, sym, Seq(head, tail)) if sym == HListConsClassSymbol =>
+        toCasFunction(head).withPrependedPath("head") :: extractHList(tail).map(_.withPrependedPath("tail"))
+    }
+  }
+
+  private def toHList(exps: Seq[SymjaExprWithSymbolTable]): ValueAndType =
+    exps.map(v => toSymbolicFunction(v))
+      .foldLeft(ValueAndType(q"shapeless.HNil", tq"shapeless.HNil")) { case (ValueAndType(listValue, listType), ValueAndType(elemValue, elemType)) =>
+        ValueAndType(q"$elemValue::$listValue", tq"shapeless.::[$elemType,$listType]")
+      }
+
+
+  private def toSymbolicFunction(expr: SymjaExprWithSymbolTable): ValueAndType = expr.symjaExpr match {
+    case Extractors.Times(vs@_*) => {
+      val ValueAndType(factorValues, factorTypes) = toHList(vs.map(expr.withExpression))
+      ValueAndType(q"breeze.symbolic.Product.apply($factorValues)", tq"breeze.symbolic.Product[$factorTypes]")
+    }
+
+    case Extractors.Plus(vs@_*) => {
+      val ValueAndType(summandValues, summandTypes) = toHList(vs.map(expr.withExpression))
+      ValueAndType(q"breeze.symbolic.Sum.apply($summandValues)", tq"breeze.symbolic.Sum[$summandTypes]")
+    }
+
+    case Extractors.Exponential(innerExp) => {
+      val ValueAndType(innerSymbolic, innerType) = toSymbolicFunction(expr.withExpression(innerExp))
+      ValueAndType(q"breeze.symbolic.Exponential.apply($innerSymbolic)", tq"breeze.symbolic.Exponential[$innerType]")
+    }
+
+    case Extractors.Logarithm(innerExp) => {
+      val ValueAndType(innerSymbolic, innerType) = toSymbolicFunction(expr.withExpression(innerExp))
+      ValueAndType(q"breeze.symbolic.Logarithm.apply($innerSymbolic)", tq"breeze.symbolic.Logarithm[$innerType]")
+    }
+
+    case Extractors.Symbol(_) => {
+      val Some((tpe, path)) = expr.pathAndTypeOfExpression
+      ValueAndType(path.tail.foldLeft(Ident(TermName(path.head)): Tree) { (lo, selector) =>
+        Select(qualifier = lo, name = TermName(selector))
+      }, tq"$tpe")
+    }
+
+    case Extractors.Power(innerExp, exponent) => {
+      val ValueAndType(innerSymbolic, innerType) = toSymbolicFunction(expr.withExpression(innerExp))
+      val ValueAndType(expSymbolic, expType) = toSymbolicFunction(expr.withExpression(exponent))
+      ValueAndType(q"breeze.symbolic.Power.apply[$innerType, $expType]($innerSymbolic, $expSymbolic)", tq"breeze.symbolic.Power[$innerType, $expType]")
+    }
+
+    case Extractors.ConstInt(value) => {
+      if (value == 0)
+        ValueAndType(q"breeze.symbolic.ConstZero.apply()", tq"breeze.symbolic.ConstZero")
+      else if (value == 1)
+        ValueAndType(q"breeze.symbolic.ConstOne.apply()", tq"breeze.symbolic.ConstOne")
+      else
+        ValueAndType(q"breeze.symbolic.Const.apply[Double]($value)", tq"breeze.symbolic.Const[Double]")
+    }
+
+    case Extractors.Derivation(innerExp) => {
+      val ValueAndType(innerSymbolic, innerType) = toSymbolicFunction(expr.withExpression(innerExp))
+      ValueAndType(q"breeze.symbolic.Derivation.apply[$innerType]($innerSymbolic)", tq"breeze.symbolic.Derivation[$innerType]")
+    }
+
+    case Extractors.Function(_) => {
+      val Some((tpe, path)) = expr.pathAndTypeOfExpression
+      ValueAndType(path.tail.foldLeft(Ident(TermName(path.head)): Tree) { (lo, selector) =>
+        Select(qualifier = lo, name = TermName(selector))
+      }, tq"$tpe")
+    }
+
+    case Extractors.Numeric(value) => {
+      if (value == 0)
+        ValueAndType(q"breeze.symbolic.ConstZero.apply()", tq"breeze.symbolic.ConstZero")
+      else if (value == 1)
+        ValueAndType(q"breeze.symbolic.ConstOne.apply()", tq"breeze.symbolic.ConstOne")
+      else
+        ValueAndType(q"breeze.symbolic.Const.apply[Double]($value)", tq"breeze.symbolic.Const[Double]")
+    }
+
+    case x => c.abort(c.enclosingPosition, s"Don't know how to transform $x into a breeze.symbolic.SymbolicFunction")
+  }
+
+  private def transform[SF: c.WeakTypeTag](inputType: Type)(transformation: IExpr => IExpr): ValueAndType = {
+    val res = toCasFunction(inputType)
+    val transformed = res.withPrependedPath("f").withMappedExpression(transformation)
+    toSymbolicFunction(transformed)
+  }
+
+  def canDerive_impl[SF: c.WeakTypeTag]: c.Tree = {
+    val inputType = c.weakTypeTag[SF].tpe
+    val ValueAndType(value, outputType) = transform(inputType) { expr =>
+      evalEngine.evaluate(Simplify(D(expr, defaultFunctionArgument)))
+    }
+    q"""
+      new breeze.symbolic.CanDerive[$inputType] {
+        type D = $outputType
+        def derivation(f: $inputType): D = {
+          $value
+        }
+      }
+    """
+  }
+
+  def canSimplify_impl[SF: c.WeakTypeTag]: c.Tree = {
+    val inputType = c.weakTypeTag[SF].tpe
+    val ValueAndType(value, outputType) = transform(inputType) { expr =>
+      evalEngine.evaluate(Simplify(expr))
+    }
+    q"""
+      new breeze.symbolic.CanSimplify[$inputType] {
+        type R = $outputType
+        def simplify(f: $inputType): R = {
+          $value
+        }
+      }
+    """
+  }
+
+}

--- a/math/src/main/scala/breeze/linalg/support/CanCreateZerosLike.scala
+++ b/math/src/main/scala/breeze/linalg/support/CanCreateZerosLike.scala
@@ -30,6 +30,9 @@ trait CanCreateZerosLike[From, +To] {
 }
 
 object CanCreateZerosLike {
+  implicit def canCreateScalarZeroes[@specialized(Int,Short,Long,Float,Double) V:Semiring] = new CanCreateZerosLike[V, V] {
+    def apply(d: V): V = implicitly[Semiring[V]].zero
+  }
 
   class OpArray[@specialized V:ClassTag:Semiring]
   extends CanCreateZerosLike[Array[V],Array[V]] {

--- a/math/src/main/scala/breeze/symbolic/CanBuildSingleArgumentFunction.scala
+++ b/math/src/main/scala/breeze/symbolic/CanBuildSingleArgumentFunction.scala
@@ -1,0 +1,16 @@
+package breeze.symbolic
+
+trait CanBuildSingleArgumentFunction[A, F[A <: SymbolicFunction[A]] <: SymbolicFunction[F[A]]] {
+  def build[I <: SymbolicFunction[I]](i: I): F[I]
+}
+
+object CanBuildSingleArgumentFunction {
+  implicit def canBuildExponential[A]: CanBuildSingleArgumentFunction[A, Exponential] = new CanBuildSingleArgumentFunction[A, Exponential] {
+      override def build[I <: SymbolicFunction[I]](i: I): Exponential[I] = new Exponential(i)
+    }
+
+  implicit def canBuildLogarithm[A]: CanBuildSingleArgumentFunction[A, Logarithm] = new CanBuildSingleArgumentFunction[A, Logarithm] {
+      override def build[I <: SymbolicFunction[I]](i: I): Logarithm[I] = new Logarithm(i)
+    }
+
+}

--- a/math/src/main/scala/breeze/symbolic/CanBuildTwoArgumentFunction.scala
+++ b/math/src/main/scala/breeze/symbolic/CanBuildTwoArgumentFunction.scala
@@ -1,0 +1,18 @@
+package breeze.symbolic
+
+trait CanBuildTwoArgumentFunction[A, B, F[A <: SymbolicFunction[A], B <: SymbolicFunction[B]] <: SymbolicFunction[F[A, B]]] {
+  def build[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2]](f1: F1, f2: F2): F[F1, F2]
+}
+
+object CanBuildTwoArgumentFunction {
+
+  implicit def canBuildDivision[A, B]: CanBuildTwoArgumentFunction[A, B, Division] = new CanBuildTwoArgumentFunction[A, B, Division] {
+    override def build[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2]](f1: F1, f2: F2): Division[F1, F2] =
+      Division(f1, f2)
+  }
+  implicit def canBuildDifference[A, B]: CanBuildTwoArgumentFunction[A, B, Difference] =
+    new CanBuildTwoArgumentFunction[A, B, Difference] {
+      override def build[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2]](f1: F1, f2: F2): Difference[F1, F2] =
+        Difference(f1, f2)
+    }
+}

--- a/math/src/main/scala/breeze/symbolic/CanCreateFunction.scala
+++ b/math/src/main/scala/breeze/symbolic/CanCreateFunction.scala
@@ -1,0 +1,234 @@
+package breeze.symbolic
+
+import breeze.generic.{MappingUFunc, UFunc}
+import breeze.linalg.DenseVector
+import breeze.linalg.operators.{OpAdd, OpDiv, OpMulScalar, OpMulMatrix, OpSub}
+import breeze.linalg.support.CanCreateZerosLike
+import breeze.numerics
+import shapeless.LUBConstraint._
+import shapeless.{::, HList, HNil}
+
+/**
+  * Type-class to create an ordinary Scala function from a SymbolicFunction
+  * @tparam I The input type of the Scala function
+  * @tparam O The output type of the Scala function
+  * @tparam F The type of the SymbolicFunction from which the Scala function is created
+  */
+trait CanCreateFunction[I, O, F <: SymbolicFunction[F]] {
+  def createFunction(f: F): I => O
+}
+
+trait LowPriorityCanCreateFunction {
+  implicit def canCreateVectorizedSymbolicFunction[I, O, F <: SymbolicFunction[F]](
+    implicit canCreateFunction: CanCreateFunction[I, O, F],
+    bf: breeze.linalg.support.CanMapKeyValuePairs[DenseVector[I], Int, I, O, DenseVector[O]]
+  ): CanCreateFunction[DenseVector[I], DenseVector[O], VectorizedSymbolicFunction[F]] =
+    new CanCreateFunction[DenseVector[I], DenseVector[O], VectorizedSymbolicFunction[F]] {
+      override def createFunction(f: VectorizedSymbolicFunction[F]): (DenseVector[I]) => DenseVector[O] = {
+        val convertedFunctions = f.fs.map(canCreateFunction.createFunction).toArray
+        (i: DenseVector[I]) => i.mapPairs { case (index, value) => convertedFunctions(index).apply(value) }
+      }
+    }
+
+  implicit def canCreateEmptyProductFunction[I, O](
+    implicit constOne: CanCreateFunction[I, O, ConstOne]
+  ): CanCreateFunction[I, O, Product[HNil]] =
+    new CanCreateFunction[I, O, Product[HNil]] {
+      def createFunction(f: Product[HNil]) = constOne.createFunction(ConstOne())
+    }
+
+  implicit def canCreateProductScalarFunction[I, O1, O2, F <: SymbolicFunction[F], L <: HList : <<:[SymbolicFunction[_]]#λ](
+    implicit ccf1: CanCreateFunction[I, O1, F],
+    ccf2: CanCreateFunction[I, O2, Product[L]],
+    multiply: OpMulMatrix.Impl2[O1, O2, O1]
+  ) = new CanCreateFunction[I, O1, Product[F :: L]] {
+    def createFunction(f: Product[F :: L]) = {
+      val f1 = ccf1.createFunction(f.fns.head)
+      val f2 = ccf2.createFunction(Product(f.fns.tail))
+                                  (i: I) =>
+      multiply(f1(i), f2(i))
+    }
+  }
+
+  implicit def canCreateEmptySumFunction[I, O](
+    implicit constZero: CanCreateFunction[I, O, ConstZero]
+  ): CanCreateFunction[I, O, Sum[HNil]] =
+    new CanCreateFunction[I, O, Sum[HNil]] {
+      def createFunction(f: Sum[HNil]) = constZero.createFunction(ConstZero())
+    }
+
+  implicit def canCreateSumFunction[I, O, S1 <: SymbolicFunction[S1], S2 <: HList : <<:[SymbolicFunction[_]]#λ](
+    implicit ccf1: CanCreateFunction[I, O, S1],
+    ccf2: CanCreateFunction[I, O, Sum[S2]],
+    add: OpAdd.Impl2[O, O, O]
+  ): CanCreateFunction[I, O, Sum[S1 :: S2]] =
+    new CanCreateFunction[I, O, Sum[S1 :: S2]] {
+      def createFunction(f: Sum[S1 :: S2]) = {
+        val f1 = ccf1.createFunction(f.fns.head)
+        val f2 = ccf2.createFunction(Sum(f.fns.tail))
+        (i: I) =>
+          add(f1(i), f2(i))
+      }
+    }
+
+  implicit def canCreateConstantFunction[I, O]: CanCreateFunction[I, O, Const[O]] =
+    new CanCreateFunction[I, O, Const[O]] {
+      def createFunction(f: Const[O]) =
+        (i: I) => f.const
+    }
+
+  implicit def canCreateConstantZeroFunction[I, O](
+    implicit zero: CanCreateZerosLike[I, O]
+  ): CanCreateFunction[I, O, ConstZero] =
+    new CanCreateFunction[I, O, ConstZero] {
+      def createFunction(f: ConstZero) =
+        (i: I) => zero(i)
+    }
+
+  implicit def canCreateConstantOneFunction[I, O](
+    implicit zero: CanCreateZerosLike[I, O], exp: numerics.exp.Impl[O, O]
+  ): CanCreateFunction[I, O, ConstOne] =
+    new CanCreateFunction[I, O, ConstOne] {
+      def createFunction(f: ConstOne) =
+        (i: I) => exp(zero(i))
+    }
+
+  implicit def canCreateVarFunction[T]: CanCreateFunction[T, T, Var] =
+    new CanCreateFunction[T, T, Var] {
+      def createFunction(f: Var) =
+        (i: T) => i
+    }
+
+  implicit def canCreateNamedVarFunction[T, S <: Symbol]: CanCreateFunction[T, T, NamedVar[S]] =
+    new CanCreateFunction[T, T, NamedVar[S]] {
+      def createFunction(f: NamedVar[S]) =
+        (i: T) => i
+    }
+
+  implicit def canCreateIdentityFunction[T]: CanCreateFunction[T, T, Identity[T]] =
+    new CanCreateFunction[T, T, Identity[T]] {
+      def createFunction(f: Identity[T]) =
+        (i: T) => i
+    }
+
+  implicit def canCreateLogarithmFunction[I, O, F <: SymbolicFunction[F]](
+    implicit canCreateFunction: CanCreateFunction[I, O, F], log: numerics.log.Impl[O, O]
+  ): CanCreateFunction[I, O, Logarithm[F]] =
+    new CanCreateFunction[I, O, Logarithm[F]] {
+      def createFunction(f: Logarithm[F]) = {
+        val fn = canCreateFunction.createFunction(f.fn)
+        (i: I) =>
+          log(fn(i))
+      }
+    }
+
+  implicit def canCreateExponentialFunction[I, O, F <: SymbolicFunction[F]](
+    implicit canCreateFunction: CanCreateFunction[I, O, F], exp: numerics.exp.Impl[O, O]
+  ): CanCreateFunction[I, O, Exponential[F]] =
+    new CanCreateFunction[I, O, Exponential[F]] {
+      def createFunction(f: Exponential[F]) = {
+        val fn = canCreateFunction.createFunction(f.fn)
+        (i: I) =>
+          exp(fn(i))
+      }
+    }
+
+  implicit def canCreatePowerFunction[I, O, F <: SymbolicFunction[F], E <: SymbolicFunction[E]](
+    implicit canCreateFunction: CanCreateFunction[I, O, F],
+    canCreateExpFunction: CanCreateFunction[I, O, E],
+    pow: numerics.pow.Impl2[O, O, O]
+  ): CanCreateFunction[I, O, Power[F, E]] =
+    new CanCreateFunction[I, O, Power[F, E]] {
+      def createFunction(f: Power[F, E]) = {
+        val fn = canCreateFunction.createFunction(f.fn)
+        val exp = canCreateExpFunction.createFunction(f.exp)
+        (i: I) =>
+          pow(fn(i), exp(i))
+      }
+    }
+
+
+  implicit def canCreateDivisionFunction[I, O, N <: SymbolicFunction[N], D <: SymbolicFunction[D]](
+    implicit canCreateFunction1: CanCreateFunction[I, O, N],
+    canCreateFunction2: CanCreateFunction[I, O, D],
+    divide: OpDiv.Impl2[O, O, O]
+  ): CanCreateFunction[I, O, Division[N, D]] =
+    new CanCreateFunction[I, O, Division[N, D]] {
+      def createFunction(f: Division[N, D]) = {
+        val f1 = canCreateFunction1.createFunction(f.fn1)
+        val f2 = canCreateFunction2.createFunction(f.fn2)
+        (i: I) =>
+          divide(f1(i), f2(i))
+      }
+    }
+
+  implicit def canCreateDifferenceFunction[I, O, V <: SymbolicFunction[V], S <: SymbolicFunction[S]](
+    implicit canCreateFunction1: CanCreateFunction[I, O, V],
+    canCreateFunction2: CanCreateFunction[I, O, S],
+    subtract: OpSub.Impl2[O, O, O]
+  ): CanCreateFunction[I, O, Difference[V, S]] =
+    new CanCreateFunction[I, O, Difference[V, S]] {
+      def createFunction(f: Difference[V, S]) = {
+        val f1 = canCreateFunction1.createFunction(f.fn1)
+        val f2 = canCreateFunction2.createFunction(f.fn2)
+        (i: I) =>
+          subtract(f1(i), f2(i))
+      }
+    }
+
+  implicit def canCreateChainFunction[I, O1, O2, Outer <: SymbolicFunction[Outer], Inner <: SymbolicFunction[Inner]](
+    implicit canCreateOuterFunction: CanCreateFunction[O1, O2, Outer],
+    canCreateInnerFunction: CanCreateFunction[I, O1, Inner]
+  ): CanCreateFunction[I, O2, Chain[Outer, Inner]] =
+    new CanCreateFunction[I, O2, Chain[Outer, Inner]] {
+      def createFunction(f: Chain[Outer, Inner]) = {
+        val f1 = canCreateOuterFunction.createFunction(f.outer)
+        val f2 = canCreateInnerFunction.createFunction(f.inner)
+        f2.andThen(f1)
+      }
+    }
+}
+
+trait MediumPriorityCanCreateFunction extends LowPriorityCanCreateFunction {
+
+  implicit def canCreateProductFunction[I, O, F <: SymbolicFunction[F], L <: HList : <<:[SymbolicFunction[_]]#λ](
+    implicit ccf1: CanCreateFunction[I, O, F],
+    ccf2: CanCreateFunction[I, O, Product[L]],
+    multiply: OpMulScalar.Impl2[O, O, O]
+  ): CanCreateFunction[I, O, Product[F :: L]] =
+    new CanCreateFunction[I, O, Product[F :: L]] {
+      def createFunction(f: Product[F :: L]) = {
+        val f1 = ccf1.createFunction(f.fns.head)
+        val f2 = ccf2.createFunction(Product(f.fns.tail))
+                                    (i: I) =>
+        multiply(f1(i), f2(i))
+      }
+    }
+
+  implicit def canCreateDenseVectorConstantScalarFunction: CanCreateFunction[DenseVector[Double], DenseVector[Double], Const[Double]] =
+    new CanCreateFunction[DenseVector[Double], DenseVector[Double], Const[Double]] {
+      def createFunction(f: Const[Double]) =
+        (i: DenseVector[Double]) => DenseVector.fill(i.length, f.const)
+    }
+
+}
+
+object CanCreateFunction extends MediumPriorityCanCreateFunction {
+  def apply[I, O, F <: SymbolicFunction[F]](implicit canCreateFunction: CanCreateFunction[I, O, F]) =
+    canCreateFunction
+
+  implicit class RichFunctionLike[F <: SymbolicFunction[F]](f: F) {
+    def toFunction[I, O](
+      implicit canCreateFunction: CanCreateFunction[I, O, F]): I => O =
+      canCreateFunction.createFunction(f)
+  }
+
+}
+
+object toFunction extends UFunc with MappingUFunc {
+  implicit def implCanCreateFunction[I, O, F <: SymbolicFunction[F]](
+    implicit canCreateFunction: CanCreateFunction[I, O, F]
+  ): Impl[F, I => O] = new Impl[F, I => O] {
+    def apply(f: F) = canCreateFunction.createFunction(f)
+  }
+}

--- a/math/src/main/scala/breeze/symbolic/CanDerive.scala
+++ b/math/src/main/scala/breeze/symbolic/CanDerive.scala
@@ -1,0 +1,29 @@
+package breeze.symbolic
+
+import breeze.generic.{MappingUFunc, UFunc}
+
+/**
+  * Type class to calculate the symbolic derivative of a SymbolicFunction
+  * @tparam F The type of the SymbolicFunction to derive
+  */
+trait CanDerive[F <: SymbolicFunction[F]] {
+  type D <: SymbolicFunction[D]
+  def derivation(f: F): D
+}
+
+object CanDerive {
+  type Aux[F <: SymbolicFunction[F], D0 <: SymbolicFunction[D0]] = CanDerive[F] { type D = D0 }
+
+  implicit class RichDerivable[F <: SymbolicFunction[F]](f: F) {
+    def derivation(implicit canDerive: CanDerive[F]): canDerive.D = canDerive.derivation(f)
+  }
+  import breeze.macros.symbolic.FunctionTransformationMacros
+  implicit def canDeriveWithMacro[F <: SymbolicFunction[F]]: CanDerive[F] =
+    macro FunctionTransformationMacros.canDerive_impl[F]
+}
+
+object derive extends UFunc with MappingUFunc {
+  implicit def implCanDerive[F <: SymbolicFunction[F]](implicit canDerive: CanDerive[F]): Impl[F, canDerive.D] = new Impl[F, canDerive.D] {
+    def apply(f: F) = canDerive.derivation(f)
+  }
+}

--- a/math/src/main/scala/breeze/symbolic/CanSimplify.scala
+++ b/math/src/main/scala/breeze/symbolic/CanSimplify.scala
@@ -1,0 +1,34 @@
+package breeze.symbolic
+
+import breeze.generic.{MappingUFunc, UFunc}
+import breeze.linalg.operators.{OpAdd, OpMulScalar}
+import breeze.numerics
+import shapeless.LUBConstraint._
+import shapeless.{::, <:!<, HList, HNil}
+
+/**
+  * Type-class to simplify a SymbolicFunction
+  * @tparam F The type of the SymbolicFunction to simplify
+  */
+trait CanSimplify[F <: SymbolicFunction[F]] {
+  type R <: SymbolicFunction[R]
+  def simplify(f: F): R
+}
+
+object CanSimplify {
+  type Aux[F <: SymbolicFunction[F], Out] = CanSimplify[F] { type R = Out }
+
+  implicit class RichSimplifiable[F <: SymbolicFunction[F]](f: F) {
+    def simplify(implicit canSimplify: CanSimplify[F]): canSimplify.R =
+      canSimplify.simplify(f)
+  }
+  import breeze.macros.symbolic.FunctionTransformationMacros
+  implicit def canSimplifyWithMacro[F <: SymbolicFunction[F]]: CanSimplify[F] =
+    macro FunctionTransformationMacros.canSimplify_impl[F]
+}
+
+object simplify extends UFunc with MappingUFunc {
+  implicit def implCanSimplify[F <: SymbolicFunction[F]](implicit canSimplify: CanSimplify[F]): Impl[F, canSimplify.R] = new Impl[F, canSimplify.R] {
+    def apply(f: F) = canSimplify.simplify(f)
+  }
+}

--- a/math/src/main/scala/breeze/symbolic/CanVectorize.scala
+++ b/math/src/main/scala/breeze/symbolic/CanVectorize.scala
@@ -1,0 +1,183 @@
+package breeze.symbolic
+
+import breeze.generic.{MappingUFunc, UFunc}
+import breeze.linalg.DenseVector
+import shapeless.labelled.FieldType
+import shapeless.ops.hlist.IsHCons
+import shapeless.ops.record.Keys
+import shapeless.{::, HList, HNil, LUBConstraint, Const => _}
+
+import scala.reflect.ClassTag
+
+/**
+  * Type-class to lift a sequence of scalar SymbolicFunctions to a vectorized representation
+  * @tparam E The type of the scalar SymbolicFunction
+  */
+trait CanVectorize[-E] {
+  type V
+  def vectorize(fs: Seq[E]): V
+}
+
+abstract class AbstractCanVectorize[-E](val name: String) extends CanVectorize[E] {
+  override def toString: String = name
+}
+
+trait LowestPriorityCanVectorize {
+  /*
+  implicit def wrapSymbolicFunctions[F <: SymbolicFunction[F]]: CanVectorize.Aux[F, VectorizedSymbolicFunction[F]] =
+    new AbstractCanVectorize[F]("F") {
+      type V = VectorizedSymbolicFunction[F]
+      override def vectorize(fs: Seq[F]): VectorizedSymbolicFunction[F] = {
+        println(s"Couldn't vectorize $fs to anything better than VectorizedSymbolicFunction")
+        VectorizedSymbolicFunction(fs)
+      }
+    }
+    */
+}
+
+trait LowPriorityCanVectorize extends LowestPriorityCanVectorize {
+
+  implicit def canVectorizeConst[T: ClassTag]: CanVectorize.Aux[Const[T], Const[DenseVector[T]]] =
+    new AbstractCanVectorize[Const[T]]("Const") {
+      type V = Const[DenseVector[T]]
+      def vectorize(fs: Seq[Const[T]]): V = Const(DenseVector(fs.map(_.const): _*))
+    }
+
+  implicit def canVectorizeConstZero: CanVectorize.Aux[ConstZero, ConstZero] =
+    new AbstractCanVectorize[ConstZero]("ConstZero") {
+      type V = ConstZero
+      def vectorize(fs: Seq[ConstZero]): V = ConstZero()
+    }
+
+  implicit def canVectorizeConstOne: CanVectorize.Aux[ConstOne, ConstOne] =
+    new AbstractCanVectorize[ConstOne]("ConstOne") {
+      type V = ConstOne
+      def vectorize(fs: Seq[ConstOne]): V = ConstOne()
+    }
+
+  implicit def canVectorizeVar: CanVectorize.Aux[Var, Var] =
+    new AbstractCanVectorize[Var]("Var") {
+      type V = Var
+      def vectorize(fs: Seq[Var]): V = Var()
+    }
+
+  implicit def canVectorizeHNil: CanVectorize.Aux[HNil, HNil] =
+    new AbstractCanVectorize[HNil]("HNil") {
+      type V = HNil
+      def vectorize(fs: Seq[HNil]): V = HNil
+    }
+
+  implicit def canVectorizeHList[F, L <: HList, T <: HList](
+    implicit canVectorizeHead: CanVectorize[F],
+    canVectorizeTail: CanVectorize.Aux[L, T]
+  ): CanVectorize.Aux[F :: L, canVectorizeHead.V :: T] =
+    new AbstractCanVectorize[F :: L]("F :: L") {
+      type V = canVectorizeHead.V :: T
+      def vectorize(fs: Seq[F :: L]): V = canVectorizeHead.vectorize(fs.map(_.head)) :: canVectorizeTail.vectorize(fs.map(_.tail))
+    }
+
+  implicit def canVectorizeExponential[F1 <: SymbolicFunction[F1], LF1 <: SymbolicFunction[LF1]](
+    implicit canVectorizeF1: CanVectorize.Aux[F1, LF1]
+  ): CanVectorize.Aux[Exponential[F1], Exponential[LF1]] =
+    new AbstractCanVectorize[Exponential[F1]]("Exponential[F1]") {
+      type V = Exponential[LF1]
+      def vectorize(fs: Seq[Exponential[F1]]) = Exponential(canVectorizeF1.vectorize(fs.map(_.fn)))
+    }
+
+  implicit def canVectorizeLogarithm[F1 <: SymbolicFunction[F1], LF1 <: SymbolicFunction[LF1]](
+    implicit canVectorizeF1: CanVectorize.Aux[F1, LF1]
+  ): CanVectorize.Aux[Logarithm[F1], Logarithm[LF1]] =
+    new AbstractCanVectorize[Logarithm[F1]]("Logarithm[F1]") {
+      type V = Logarithm[LF1]
+      def vectorize(fs: Seq[Logarithm[F1]]) = Logarithm(canVectorizeF1.vectorize(fs.map(_.fn)))
+    }
+
+  implicit def canVectorizePower[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2], LF1 <: SymbolicFunction[LF1], LF2 <: SymbolicFunction[LF2]](
+    implicit canVectorizeF1: CanVectorize.Aux[F1, LF1],
+    canVectorizeF2: CanVectorize.Aux[F2, LF2]
+  ): CanVectorize.Aux[Power[F1, F2], Power[LF1, LF2]] =
+    new AbstractCanVectorize[Power[F1, F2]]("Power[F1, F2]") {
+      type V = Power[LF1, LF2]
+      def vectorize(fs: Seq[Power[F1, F2]]) = Power(canVectorizeF1.vectorize(fs.map(_.fn)), canVectorizeF2.vectorize(fs.map(_.exp)))
+    }
+
+  implicit def canVectorizeProduct[L <: HList, VL <: HList](
+    implicit canVectorizeHList: CanVectorize.Aux[L, VL],
+    vectorizedListAllSymbolicFunction: LUBConstraint[VL, SymbolicFunction[_]]
+  ): CanVectorize.Aux[Product[L], Product[VL]] =
+    new AbstractCanVectorize[Product[L]]("Product[L]") {
+      type V = Product[VL]
+      def vectorize(fs: Seq[Product[L]]): V = Product(canVectorizeHList.vectorize(fs.map(_.fns)))
+    }
+
+  implicit def canVectorizeDivision[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2], LF1 <: SymbolicFunction[LF1], LF2 <: SymbolicFunction[LF2]](
+    implicit canVectorizeF1: CanVectorize.Aux[F1, LF1],
+    canVectorizeF2: CanVectorize.Aux[F2, LF2]
+  ): CanVectorize.Aux[Division[F1, F2], Division[LF1, LF2]] =
+    new AbstractCanVectorize[Division[F1, F2]]("Division[F1, F2]") {
+      type V = Division[LF1, LF2]
+      def vectorize(fs: Seq[Division[F1, F2]]) = Division(canVectorizeF1.vectorize(fs.map(_.fn1)), canVectorizeF2.vectorize(fs.map(_.fn2)))
+    }
+
+
+  implicit def canVectorizeSum[L <: HList, VL <: HList](
+    implicit canVectorizeHList: CanVectorize.Aux[L, VL],
+    vectorizedListAllSymbolicFunction: LUBConstraint[VL, SymbolicFunction[_]]
+  ): CanVectorize.Aux[Sum[L], Sum[VL]] =
+    new AbstractCanVectorize[Sum[L]]("Sum[L]") {
+      type V = Sum[VL]
+      def vectorize(fs: Seq[Sum[L]]): V = Sum(canVectorizeHList.vectorize(fs.map(_.fns)))
+    }
+
+  implicit def canVectorizeDifference[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2], LF1 <: SymbolicFunction[LF1], LF2 <: SymbolicFunction[LF2]](
+    implicit canVectorizeF1: CanVectorize.Aux[F1, LF1],
+    canVectorizeF2: CanVectorize.Aux[F2, LF2]
+  ): CanVectorize.Aux[Difference[F1, F2], Difference[LF1, LF2]] =
+    new AbstractCanVectorize[Difference[F1, F2]]("Difference[F1, F2]") {
+      type V = Difference[LF1, LF2]
+      def vectorize(fs: Seq[Difference[F1, F2]]) = Difference(canVectorizeF1.vectorize(fs.map(_.fn1)), canVectorizeF2.vectorize(fs.map(_.fn2)))
+    }
+
+  implicit def canVectorizeDoublesToDenseVector: CanVectorize.Aux[Double, DenseVector[Double]] =
+    new AbstractCanVectorize[Double]("Double") {
+      type V = DenseVector[Double]
+      override def vectorize(fs: Seq[Double]): DenseVector[Double] =
+        DenseVector(fs: _*)
+    }
+}
+
+object CanVectorize extends LowPriorityCanVectorize {
+  type Aux[E, V0] = CanVectorize[E] { type V = V0 }
+  implicit class RichVectorizable[E](fs: Seq[E]) {
+    def vectorized(implicit canVectorize: CanVectorize[E]): canVectorize.V = canVectorize.vectorize(fs)
+  }
+  case class SingletonOf[T, U <: { type V }](widen: T { type V = U#V })
+  object SingletonOf {
+    implicit def mkSingleton[T <: {type V}](implicit t: T): SingletonOf[T, t.type] =
+      SingletonOf[T, t.type](t)
+  }
+
+
+  implicit def canVectorizeLabelledHList[K, V0, L <: HList, TL <: HList, KL <: HList, LL <: HList](
+    implicit canVectorizeHead: CanVectorize[V0],
+    canVectorizeTail: CanVectorize.Aux[L, TL],
+    keys: Keys.Aux[FieldType[K, V0] :: L, KL],
+    isHCons: IsHCons[KL]
+  ): CanVectorize.Aux[FieldType[K, V0] :: L, FieldType[isHCons.H, canVectorizeHead.V] :: TL] =
+    new AbstractCanVectorize[FieldType[K, V0] :: L]("FieldType[K, V0] :: L") {
+      type V = FieldType[isHCons.H, canVectorizeHead.V] :: TL
+      def vectorize(fs: Seq[FieldType[K, V0] :: L]): V = {
+        val headKey: isHCons.H = keys().head
+        val headValue: canVectorizeHead.V = canVectorizeHead.vectorize(fs.map(_.head))
+        val tails = fs.map(_.tail)
+        (headValue.asInstanceOf[FieldType[isHCons.H, canVectorizeHead.V]]) :: canVectorizeTail.vectorize(tails)
+      }
+    }
+
+}
+
+object vectorize extends UFunc with MappingUFunc {
+  implicit def implCanVectorize[F](implicit canVectorize: CanVectorize[F]): Impl[Seq[F], canVectorize.V] = new Impl[Seq[F], canVectorize.V] {
+    def apply(f: Seq[F]) = canVectorize.vectorize(f)
+  }
+}

--- a/math/src/main/scala/breeze/symbolic/SymbolicFunction.scala
+++ b/math/src/main/scala/breeze/symbolic/SymbolicFunction.scala
@@ -1,0 +1,194 @@
+package breeze.symbolic
+
+import shapeless.LUBConstraint.<<:
+import shapeless._
+
+import scala.util.matching.Regex
+import breeze.linalg._
+import breeze.linalg.operators.{OpAdd, OpDiv, OpMulScalar, OpSub}
+import breeze.numerics._
+import shapeless.ops.hlist.Prepend
+
+/**
+  * Base trait for all symbolic functions.
+  * Not sealed because we want to allow users to
+  * create their own subclasses.
+  */
+trait SymbolicFunction[+F <: SymbolicFunction[F]] extends NumericOps[F] /* { self: F =>
+  override def repr: F = self
+}*/
+
+case class Var() extends SymbolicFunction[Var] {
+  override def toString = "Var"
+  override def repr: Var = this
+}
+
+case class NamedVar[N <: Symbol](implicit nameWitness: Witness.Aux[N]) extends SymbolicFunction[NamedVar[N]] {
+  override def toString = s"${nameWitness.value}"
+  override def repr: NamedVar[N] = this
+}
+
+case class Identity[T]() extends SymbolicFunction[Identity[T]] {
+  override def toString = "Identity"
+  override def repr: Identity[T] = this
+}
+
+trait SingleArgumentFunction[F <: SymbolicFunction[F], +This <: SingleArgumentFunction[F, This]] extends SymbolicFunction[This] {
+  def fn: F
+}
+
+
+case class Power[I <: SymbolicFunction[I], E <: SymbolicFunction[E]](fn: I, exp: E) extends SingleArgumentFunction[I, Power[I, E]] {
+  override def toString = s"pow($fn,$exp)"
+  override def repr: Power[I, E] = this
+}
+
+case class Exponential[I <: SymbolicFunction[I]](fn: I) extends SingleArgumentFunction[I, Exponential[I]] {
+  override def toString = s"exp($fn)"
+  override def repr: Exponential[I] = this
+}
+
+case class Logarithm[F <: SymbolicFunction[F]](fn: F) extends SingleArgumentFunction[F, Logarithm[F]] {
+  override def toString = s"log($fn)"
+  override def repr: Logarithm[F] = this
+}
+
+
+trait MultipleArgumentFunction[L <: HList, +This <: MultipleArgumentFunction[L, This]] extends SymbolicFunction[This] {
+  def fns: L
+
+  def operatorSymbol: String
+
+  override def toString =
+    s"($fns)"
+      .replaceAll(" :: ", s" $operatorSymbol ")
+      .replaceAll(s" ${Regex.quote(operatorSymbol)} HNil", "")
+}
+
+case class Sum[L <: HList : <<:[SymbolicFunction[_]]#λ](fns: L) extends MultipleArgumentFunction[L, Sum[L]] {
+  override def operatorSymbol = "+"
+  override def repr: Sum[L] = this
+}
+
+case class Product[L <: HList : <<:[SymbolicFunction[_]]#λ](fns: L) extends MultipleArgumentFunction[L, Product[L]] {
+  override def operatorSymbol = "*"
+  override def repr: Product[L] = this
+}
+
+trait TwoArgumentFunction[+F1 <: SymbolicFunction[_], +F2 <: SymbolicFunction[_], +This <: TwoArgumentFunction[F1, F2, This]] extends SymbolicFunction[This] {
+  def fn1: F1
+  def fn2: F2
+}
+
+case class Division[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2]](fn1: F1, fn2: F2)
+  extends TwoArgumentFunction[F1, F2, Division[F1, F2]] {
+  override def toString = s"$fn1 / $fn2"
+  override def repr: Division[F1, F2] = this
+}
+
+
+case class Difference[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2]](fn1: F1, fn2: F2)
+  extends TwoArgumentFunction[F1, F2, Difference[F1, F2]] {
+  override def toString = s"($fn1 - $fn2)"
+  override def repr: Difference[F1, F2] = this
+}
+
+
+trait ConstBase[+This <: ConstBase[This]] extends SymbolicFunction[This]
+
+case class Const[T](const: T) extends ConstBase[Const[T]] {
+  override def toString = const.toString
+  override def repr: Const[T] = this
+}
+
+/*
+  * Having special ConstZero and ConstOne classes
+  * allows us to retain compile-time information on zeroness
+  * which can be used to e.g. simplify functions.
+  */
+case class ConstZero() extends ConstBase[ConstZero] {
+  // We're using 0.00 here in order to more easily distinguish it from a Double value of 0.0
+  override def toString = "0.00"
+  override def repr: ConstZero = this
+}
+
+case class ConstOne() extends ConstBase[ConstOne] {
+  // We're using 1.00 here in order to more easily distinguish it from a Double value of 1.0
+  override def toString = "1.00"
+  override def repr: ConstOne = this
+}
+
+case class Chain[H <: SymbolicFunction[H], G <: SymbolicFunction[G]](outer: H, inner: G) extends SymbolicFunction[Chain[H, G]] {
+  override def toString = s"$outer($inner)"
+  override def repr: Chain[H, G] = this
+}
+
+case class Inversion[F <: SymbolicFunction[F]](f: F) extends SymbolicFunction[Inversion[F]] {
+  override def toString = s"Inverse($f)"
+  override def repr: Inversion[F] = this
+}
+
+case class Derivation[F <: SymbolicFunction[F]](f: F) extends SymbolicFunction[Derivation[F]] {
+  override def toString: String = s"Derivation($f)"
+  override def repr: Derivation[F] = this
+}
+
+case class VectorizedSymbolicFunction[F <: SymbolicFunction[F]](fs: Seq[F]) extends SymbolicFunction[VectorizedSymbolicFunction[F]] {
+  override def repr: VectorizedSymbolicFunction[F] = this
+}
+
+trait LowPrioritySymbolicFunctionImplicits {
+  implicit def addSymbolicFunctions[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2]]: OpAdd.Impl2[F1, F2, Sum[F1 :: F2 :: HNil]] = new OpAdd.Impl2[F1, F2, Sum[F1 :: F2 :: HNil]] {
+    override def apply(f1: F1, f2: F2): Sum[F1 :: F2 :: HNil] = {
+      Sum(f1 :: f2 :: HNil)
+    }
+  }
+
+  implicit def subtractSymbolicFunctions[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2]]: OpSub.Impl2[F1, F2, Difference[F1, F2]] = new OpSub.Impl2[F1, F2, Difference[F1, F2]] {
+    override def apply(f1: F1, f2: F2): Difference[F1, F2] = {
+      Difference(f1, f2)
+    }
+  }
+
+  implicit def multiplySymbolicFunctions[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2]]: OpMulScalar.Impl2[F1, F2, Product[F1 :: F2 :: HNil]] = new OpMulScalar.Impl2[F1, F2, Product[F1 :: F2 :: HNil]] {
+    override def apply(f1: F1, f2: F2): Product[F1 :: F2 :: HNil] = {
+      Product(f1 :: f2 :: HNil)
+    }
+  }
+
+  implicit def divideSymbolicFunctions[F1 <: SymbolicFunction[F1], F2 <: SymbolicFunction[F2]]: OpDiv.Impl2[F1, F2, Division[F1, F2]] = new OpDiv.Impl2[F1, F2, Division[F1, F2]] {
+    override def apply(f1: F1, f2: F2): Division[F1, F2] = {
+      Division(f1, f2)
+    }
+  }
+}
+
+object SymbolicFunction extends LowPrioritySymbolicFunctionImplicits {
+  implicit def logSymbolicFunction[F <: SymbolicFunction[F]]: log.Impl[F, Logarithm[F]] = new log.Impl[F, Logarithm[F]] {
+    def apply(f: F) = Logarithm(f)
+  }
+
+  implicit def expSymbolicFunction[F <: SymbolicFunction[F]]: exp.Impl[F, Exponential[F]] = new exp.Impl[F, Exponential[F]] {
+    def apply(f: F) = Exponential(f)
+  }
+
+  implicit def sumOfSymbolicFunctionSums[L <: HList : <<:[SymbolicFunction[_]]#λ, F <: SymbolicFunction[F], Out <: HList](
+    implicit prepend: Prepend.Aux[L, F :: HNil, Out],
+    ev: LUBConstraint[Out, SymbolicFunction[_]]
+  ): OpAdd.Impl2[Sum[L], F, Sum[Out]] =
+    new OpAdd.Impl2[Sum[L], F, Sum[Out]] {
+    override def apply(l: Sum[L], f: F): Sum[Out] = {
+      Sum(l.fns ::: f :: HNil)
+    }
+  }
+
+  implicit def productOfSymbolicFunctionProducts[L <: HList : <<:[SymbolicFunction[_]]#λ, F <: SymbolicFunction[F], Out <: HList](
+    implicit prepend: Prepend.Aux[L, F :: HNil, Out],
+    ev: LUBConstraint[Out, SymbolicFunction[_]]
+  ): OpMulScalar.Impl2[Product[L], F, Product[Out]] =
+    new OpMulScalar.Impl2[Product[L], F, Product[Out]] {
+      override def apply(l: Product[L], f: F): Product[Out] = {
+        Product(l.fns ::: f :: HNil)
+      }
+    }
+}

--- a/math/src/test/scala/breeze/symbolic/CanDeriveTest.scala
+++ b/math/src/test/scala/breeze/symbolic/CanDeriveTest.scala
@@ -1,0 +1,66 @@
+package breeze.symbolic
+
+import org.junit.runner.RunWith
+import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.prop.Checkers
+
+/**
+  * These tests check that for a function <code>f</code> and a point <code>x</code>
+  * the following equations should hold for small <code>delta</code>s:
+  * <code>f(x) - f(x - delta) =~ f'(x)<code>
+  * <code>f(x + delta) - f(x) =~ f'(x)<code>
+  *
+  * The definitions of the functions <code>f</code> has to be crafted so that
+  * we don't run into edge cases where the derivation is <code>NaN</code>.
+  */
+@RunWith(classOf[JUnitRunner])
+class CanDeriveTest extends FunSuite with Checkers with Matchers {
+  val complicatedFunction = Var() *:* Exponential(Var() - Const(1.0) +:+ Division(Const(3.0), Var() +:+ Const(50.0))) +:+ Var()
+
+  test("derives constants") {
+    testDerivation(Const(100.0))
+  }
+
+  test("derives variables") {
+    testDerivation(Var())
+  }
+
+  test("derives complicated formulas") {
+    testDerivation(complicatedFunction)
+  }
+
+  test("derives chains") {
+    val func = Chain(complicatedFunction, Var() *:* Const(0.5) +:+ Const(15.0))
+    testDerivation(func)
+  }
+
+  def testDerivation[SF <: SymbolicFunction[SF], D <: SymbolicFunction[D]](sf: SF)(
+    implicit canCreateFunction: CanCreateFunction[Double, Double, SF],
+    canDerive: CanDerive.Aux[SF, D],
+    canCreateDerivationFunction: CanCreateFunction[Double, Double, D]
+  ): Unit = {
+    val func = canCreateFunction.createFunction(sf)
+    val derivedSymbolicFunction = canDerive.derivation(sf)
+    // Helpful for debugging
+    // println(s"F  = $sf\nF' = $derivedSymbolicFunction")
+    val derivedFunc = canCreateDerivationFunction.createFunction(derivedSymbolicFunction)
+    (-20.0 to 20.0 by 0.5).foreach { x =>
+      val value = func(x)
+      val derivation = derivedFunc(x)
+      // Derivation behaves linearly in close proximity
+      val distance = 0.01
+      val diffLeft = value - func(x - distance)
+      val diffRight = func(x + distance) - value
+      if (derivation != 0.0 &&
+        !diffLeft.isInfinity && !diffRight.isInfinity &&
+        !diffLeft.isNaN && !diffRight.isNaN
+      ) {
+        // Helpful for debugging:
+        // println(s"For x = $x comparing $diffLeft <=> ${derivation * distance} <=> $diffRight")
+        (derivation * distance) should be(diffLeft +- 0.1 * diffLeft.abs)
+        (derivation * distance) should be(diffRight +- 0.1 * diffRight.abs)
+      }
+    }
+  }
+}

--- a/math/src/test/scala/breeze/symbolic/CanVectorizeTest.scala
+++ b/math/src/test/scala/breeze/symbolic/CanVectorizeTest.scala
@@ -1,0 +1,68 @@
+package breeze.symbolic
+
+import breeze.linalg.DenseVector
+import CanVectorize._
+import org.junit.runner.RunWith
+import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.prop.Checkers
+
+/**
+  * These tests check that vectorizing a <code>Seq[SymbolicFunction[_]]</code> yields the same values
+  * as evaluating the functions from the sequence individually and then putting them into a vector.
+  */
+@RunWith(classOf[JUnitRunner])
+class CanVectorizeTest extends FunSuite with Checkers with Matchers {
+  val complicatedFunction = Var() *:* Exponential(Var() - Const(1.0) +:+ Division(Const(3.0), Var() +:+ Const(50.0))) +:+ Var()
+
+  test("vectorizes constants") {
+    testVectorization(Const(100.0))
+  }
+
+  test("vectorizes variables") {
+    testVectorization(Var())
+  }
+
+  test("vectorizes complicated formulas") {
+    testVectorization(complicatedFunction)
+  }
+
+  test("vectorizes shapeless records") {
+    import shapeless._
+    import shapeless.record._
+    import shapeless.syntax.singleton._
+    val funcRecord = ("foo" ->> Const(1.0)) :: ("bar" ->> complicatedFunction) :: HNil
+    val funcRecordVectorized = vectorize(Seq(funcRecord))
+    compareOriginalAndVectorized(funcRecord("foo"), funcRecordVectorized("foo"))
+    compareOriginalAndVectorized(funcRecord("bar"), funcRecordVectorized("bar"))
+  }
+
+  def testVectorization[SF <: SymbolicFunction[SF], SFV <: SymbolicFunction[SFV]](sf: SF)(
+    implicit canCreateFunction: CanCreateFunction[Double, Double, SF],
+    canVectorize: CanVectorize.Aux[SF, SFV],
+    canCreateVectorizedFunction: CanCreateFunction[DenseVector[Double], DenseVector[Double], SFV]
+  ): Unit = {
+    val vectorizedSymbolicFunction = canVectorize.vectorize(Seq(sf))
+    compareOriginalAndVectorized(sf, vectorizedSymbolicFunction)
+  }
+
+  def compareOriginalAndVectorized[SFV <: SymbolicFunction[SFV], SF <: SymbolicFunction[SF]](
+    sf: SF,
+    vectorizedSymbolicFunction: SFV
+  )(
+    implicit canCreateFunction: CanCreateFunction[Double, Double, SF],
+    canCreateVectorizedFunction: CanCreateFunction[DenseVector[Double], DenseVector[Double], SFV]
+  ): Unit = {
+    val func = canCreateFunction.createFunction(sf)
+    // Helpful for debugging
+    // println(s"F  = $sf\nF' = $vectorizedSymbolicFunction")
+    val vectorizedFunc = canCreateVectorizedFunction.createFunction(vectorizedSymbolicFunction)
+    (-20.0 to 20.0 by 0.5).foreach { x =>
+      val value = func(x)
+      val vector = vectorizedFunc(DenseVector(x))
+      // Helpful for debugging:
+      // println(s"For x = $x comparing $diffLeft <=> ${Vectorization * distance} <=> $diffRight")
+      (vector(0)) should be(value)
+    }
+  }
+}


### PR DESCRIPTION
This PR is _not yet ready to merge_ (it lacks tests, documentation and some improvements), but we'd like to get early feedback and code reviews.
It contains a set of SymbolicFunction classes and type classes to perform derivation, simplification, vectorization and conversion into ordinary Scala functions on them.
Currently, all computations are done by the compiler itself, although one could consider the use of macros which employ some JVM-based Computational Algebra System to perform advanced simplifications.

We're happy about all forms of feedback, especially about ideas on how to perform a function simplification that doesn't stop after one pass.
