### PR TITLE
Fix edge case to allow transposing zero size DenseMatrix

### DIFF
--- a/math/src/main/scala/breeze/linalg/DenseMatrix.scala
+++ b/math/src/main/scala/breeze/linalg/DenseMatrix.scala
@@ -74,7 +74,7 @@ final class DenseMatrix[@spec(Double, Int, Float, Long) V](val rows: Int,
   if (offset < 0) { throw new IndexOutOfBoundsException("Offset must be larger than zero. It was " + offset) }
   if (majorStride > 0) {
     if (data.length < linearIndex(rows-1, cols-1)) { throw new IndexOutOfBoundsException("Storage array has size " + data.size + " but indices can grow as large as " + linearIndex(rows-1,cols-1)) }
-  } else {
+  } else if (majorStride < 0) {
     if (data.length< linearIndex(rows-1,0)) { throw new IndexOutOfBoundsException("Storage array has size " + data.size + " but indices can grow as large as " + linearIndex(rows-1,cols-1)) }
     if (linearIndex(0, cols-1) < 0) { throw new IndexOutOfBoundsException("Storage array has negative stride " + majorStride + " and offset " + offset + " which can result in negative indices.") }
   }

--- a/math/src/test/scala/breeze/linalg/DenseMatrixTest.scala
+++ b/math/src/test/scala/breeze/linalg/DenseMatrixTest.scala
@@ -761,5 +761,12 @@ class DenseMatrixTest extends FunSuite with Checkers with Matchers with DoubleIm
     assert(matrix.cols == 0)
   }
 
+   test("#577: Empty DenseMatrix can be transposed") {
+    val m = new DenseMatrix(0, 0, Array.empty[Double])
+    val mt = m.t
+    assert(mt.rows == 0)
+    assert(mt.cols == 0)
+    assert(m === mt)
+  }
 
 }


### PR DESCRIPTION
If I am not mistaken zero size DenseMatrix can be supported for transposing if we fix the construction time assertions logic. This was reported by user in #577 
