### PR TITLE
Fix computation of rSquared in leastSquares

### DIFF
--- a/math/src/main/scala/breeze/stats/regression/LeastSquares.scala
+++ b/math/src/main/scala/breeze/stats/regression/LeastSquares.scala
@@ -9,23 +9,28 @@ import java.util.Arrays
 private object leastSquaresImplementation {
   def doLeastSquares(data: DenseMatrix[Double], outputs: DenseVector[Double], workArray: Array[Double]): LeastSquaresRegressionResult = {
     require(data.rows == outputs.size)
-    require(data.rows > data.cols)
-    require(data.rows == outputs.size)
-    require(workArray.size >= 2*data.rows*data.cols)
+    require(data.rows > data.cols+1)
+    require(workArray.length >= 2*data.rows*data.cols)
 
     val info = new intW(0)
-    lapack.dgels("N", data.rows, data.cols, 1, data.data, data.rows, outputs.data, data.rows, workArray, workArray.size, info)
+    lapack.dgels("N", data.rows, data.cols, 1, data.data, data.rows, outputs.data, data.rows, workArray, workArray.length, info)
     if (info.`val` < 0) {
       throw new ArithmeticException("Least squares did not converge.")
     }
 
-    val resultVec = new DenseVector[Double](Arrays.copyOf(outputs.data, data.cols))
-    LeastSquaresRegressionResult(resultVec, math.pow(outputs.data(data.cols+1), 2))
+    val coefficients = new DenseVector[Double](Arrays.copyOf(outputs.data, data.cols))
+    var r2 = 0.0
+    for (i <- 0 until (data.rows - data.cols)) {
+      r2 = r2 + math.pow(outputs.data(data.cols+i), 2)
+    }
+    LeastSquaresRegressionResult(coefficients, r2)
   }
 }
 
 case class LeastSquaresRegressionResult(coefficients: DenseVector[Double], rSquared: Double) extends RegressionResult[DenseVector[Double], Double] {
   def apply(x: DenseVector[Double]): Double = coefficients.dot(x)
+
+  def apply(X: DenseMatrix[Double]): DenseVector[Double] = X*coefficients
 }
 
 object leastSquares extends UFunc {


### PR DESCRIPTION
Hi all.

I fixed rSquared computation as seem in this example: https://software.intel.com/sites/products/documentation/doclib/mkl_sa/11/mkl_lapack_examples/lapacke_dgels_row.c.htm

I have also added a interface to accept a matrix in `LeastSquaresRegressionResult` case class.
