### PR TITLE
Show correct cosineDistance formula in scaladoc

### DIFF
--- a/math/src/main/scala/breeze/linalg/functions/cosineDistance.scala
+++ b/math/src/main/scala/breeze/linalg/functions/cosineDistance.scala
@@ -5,7 +5,7 @@ import breeze.linalg._
 import breeze.linalg.operators.OpMulInner
 
 /**
- * The cosine distance between two points: cosineDistance(a,b) = (a dot b)/(norm(a) * norm(b))
+ * The cosine distance between two points: cosineDistance(a,b) = 1 - (a dot b)/(norm(a) * norm(b))
  */
 object cosineDistance extends UFunc {
   implicit def cosineDistanceFromDotProductAndNorm[T, U](implicit dot: OpMulInner.Impl2[T, U, Double],


### PR DESCRIPTION
The documented behavior of this function is that it returns cosine(a, b). The cosine is (a dot b)/(norm(a) * norm(b)). This is 1.0 if the two vectors are equal, and 0.0 if they are orthogonal.  cosineDistance(a, b) = 1 - cosine(a, b).  

https://reference.wolfram.com/language/ref/CosineDistance.html