### PR TITLE
slight bugfix

### DIFF
--- a/math/src/main/scala/breeze/stats/distributions/NegativeBinomial.scala
+++ b/math/src/main/scala/breeze/stats/distributions/NegativeBinomial.scala
@@ -8,7 +8,7 @@ import breeze.numerics._
  * @param p prob of success
  * @author dlwh
  */
-case class NegativeBinomial(r: Double, p: Double) extends DiscreteDistr[Int] {
+case class NegativeBinomial(r: Double, p: Double)(implicit rand: RandBasis=Rand) extends DiscreteDistr[Int] {
   private val gen = for {
     lambda <- Gamma(r,p / (1-p))
     i <- Poisson(lambda)


### PR DESCRIPTION
lack of (implicit rand: RandBasis=Rand) causes defalt Rand being used in Gamma and Poisson distributions.