### PR TITLE
Bug fixes and improvements to code relating to Metropolis-Hastings based MCMC

### DIFF
--- a/math/src/main/scala/breeze/stats/distributions/MarkovChain.scala
+++ b/math/src/main/scala/breeze/stats/distributions/MarkovChain.scala
@@ -192,9 +192,9 @@ object MarkovChain {
       for(next <- proposal(t);
           newLL = logMeasure(next);
           oldLL = logMeasure(t);
-          a = min(1,exp(newLL - oldLL));
+          a = newLL - oldLL;
           u <- rand.uniform) 
-        yield if(u < a) next else t;
+        yield if(log(u) < a) next else t;
     }
 
     /**
@@ -207,14 +207,12 @@ object MarkovChain {
       val prop = proposal(t);
       for(next <- prop;
         newLL = logMeasure(next);
-        //newP = prop.logApply(next);
         newP = prop.logPdf(next);
         oldLL = logMeasure(t);
-        //oldP = proposal(next).logApply(t);
         oldP = proposal(next).logPdf(t);
-        a = min(1,exp(newLL - newP - oldLL + oldP));
+        a = newLL - newP - oldLL + oldP;
         u <- rand.uniform)
-      yield if(u < a) next else t;
+      yield if(log(u) < a) next else t;
     }
 
     /**

--- a/math/src/main/scala/breeze/stats/distributions/MarkovChain.scala
+++ b/math/src/main/scala/breeze/stats/distributions/MarkovChain.scala
@@ -202,15 +202,17 @@ object MarkovChain {
     * @param proposal the proposal distribution generator
     *
     */
-    def metropolisHastings[T](proposal: T =>(Density[T] with Rand[T]))
+    def metropolisHastings[T](proposal: T =>ContinuousDistr[T])
                              (logMeasure: T=>Double)(implicit rand:RandBasis=Rand)= { t:T =>
       val prop = proposal(t);
       for(next <- prop;
         newLL = logMeasure(next);
-        newP = prop.logApply(next);
+        //newP = prop.logApply(next);
+        newP = prop.logPdf(next);
         oldLL = logMeasure(t);
-        oldP = prop.logApply(t);
-        a = min(1,exp(newLL + newP - oldLL - oldP));
+        //oldP = proposal(next).logApply(t);
+        oldP = proposal(next).logPdf(t);
+        a = min(1,exp(newLL - newP - oldLL + oldP));
         u <- rand.uniform)
       yield if(u < a) next else t;
     }
@@ -291,8 +293,8 @@ object MarkovChain {
   * @param proposal the proposal distribution generator
   *
   */
-  def metropolisHastings[T](init : T, proposal : T =>(Density[T] with Rand[T]))(logMeasure: T=>Double) = {
-    MarkovChain(init) { Kernels.metropolisHastings(proposal){logMeasure}};
+  def metropolisHastings[T](init : T, proposal : T =>ContinuousDistr[T])(logMeasure: T=>Double) = {
+    MarkovChain(init)(Kernels.metropolisHastings(proposal)(logMeasure))
   }
 
    

--- a/math/src/test/scala/breeze/stats/distributions/MarkovChainTest.scala
+++ b/math/src/test/scala/breeze/stats/distributions/MarkovChainTest.scala
@@ -1,7 +1,7 @@
 package breeze.stats.distributions;
 
 /*
- Copyright 2009 David Hall, Daniel Ramage
+ Copyright 2017 David Hall, Daniel Ramage
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/math/src/test/scala/breeze/stats/distributions/MarkovChainTest.scala
+++ b/math/src/test/scala/breeze/stats/distributions/MarkovChainTest.scala
@@ -1,0 +1,72 @@
+package breeze.stats.distributions;
+
+/*
+ Copyright 2009 David Hall, Daniel Ramage
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import org.junit.runner.RunWith
+import org.scalacheck._
+import org.scalatest._
+import org.scalatest.junit._
+import org.scalatest.prop._
+
+@RunWith(classOf[JUnitRunner])
+class MarkovChainTest extends FunSuite with Checkers {
+  type Distr = Gamma
+  import org.scalacheck.Arbitrary.arbitrary
+
+  import breeze.numerics._
+  import breeze.linalg._
+  import MarkovChain._
+
+  val numSamples = 1000000
+  val tol = 0.01
+
+  test("metropolis for a Gamma") {
+    val mc = metropolis(1.0,(x: Double) =>
+      Gaussian(x, 1.0))(x => Gamma(2.0, 1.0/3).logPdf(x))
+    val it = mc.steps
+    val its = it.take(numSamples).toArray
+    val itsv = DenseVector[Double](its)
+    val mav = breeze.stats.meanAndVariance(itsv)
+    assert(abs(mav.mean-2.0/3) < tol)
+    assert(abs(mav.variance-2.0/9) < tol)
+  }
+
+  test("metropolisHastings for a Gamma with a symmetric proposal") {
+    val mc = metropolisHastings(1.0,(x: Double) =>
+      Gaussian(x, 1.0))(x => Gamma(2.0, 1.0/3).logPdf(x))
+    val it = mc.steps
+    val its = it.take(numSamples).toArray
+    val itsv = DenseVector[Double](its)
+    val mav = breeze.stats.meanAndVariance(itsv)
+    assert(abs(mav.mean-2.0/3) < tol)
+    assert(abs(mav.variance-2.0/9) < tol)
+  }
+
+  test("metropolisHastings for a Gamma with a non-symmetric proposal") {
+    val mc = metropolisHastings(1.0,(x: Double) =>
+      Gaussian(x, 1.0+x))(x => Gamma(2.0, 1.0/3).logPdf(x))
+    val it = mc.steps
+    val its = it.take(numSamples).toArray
+    val itsv = DenseVector[Double](its)
+    val mav = breeze.stats.meanAndVariance(itsv)
+    assert(abs(mav.mean-2.0/3) < tol)
+    assert(abs(mav.variance-2.0/9) < tol)
+  }
+
+
+
+}

--- a/math/src/test/scala/breeze/stats/distributions/MarkovChainTest.scala
+++ b/math/src/test/scala/breeze/stats/distributions/MarkovChainTest.scala
@@ -22,6 +22,10 @@ import org.scalatest._
 import org.scalatest.junit._
 import org.scalatest.prop._
 
+/**Tests for MarkovChain
+ * @author darrenjw
+ * @date 2/1/17
+ */
 @RunWith(classOf[JUnitRunner])
 class MarkovChainTest extends FunSuite with Checkers {
   type Distr = Gamma

--- a/math/src/test/scala/breeze/stats/mcmc/metropolisTest.scala
+++ b/math/src/test/scala/breeze/stats/mcmc/metropolisTest.scala
@@ -21,7 +21,7 @@ class metropolisTest extends FunSuite {
   case object B extends State
   case object C extends State
 
-  private val NUM_TESTS = 2000000
+  private val NUM_TESTS = 900000
   private val DROP_COUNT = 2
 
   private val l6 = math.log(6) //performance hack
@@ -35,7 +35,7 @@ class metropolisTest extends FunSuite {
 
   val proposal = rand.choose(Seq(A,B,C))
 
-  val TOLERANCE = 0.03
+  val TOLERANCE = 0.05
 
   test("stupidly simple mcmc") {
     val mh = ArbitraryMetropolisHastings(logLikelihood _, (_:State) => proposal, (_:State,_:State) => 0.0, A, burnIn = 10000, dropCount=DROP_COUNT)

--- a/math/src/test/scala/breeze/stats/mcmc/metropolisTest.scala
+++ b/math/src/test/scala/breeze/stats/mcmc/metropolisTest.scala
@@ -21,7 +21,7 @@ class metropolisTest extends FunSuite {
   case object B extends State
   case object C extends State
 
-  private val NUM_TESTS = 900000
+  private val NUM_TESTS = 2000000
   private val DROP_COUNT = 2
 
   private val l6 = math.log(6) //performance hack
@@ -35,7 +35,7 @@ class metropolisTest extends FunSuite {
 
   val proposal = rand.choose(Seq(A,B,C))
 
-  val TOLERANCE = 0.1
+  val TOLERANCE = 0.03
 
   test("stupidly simple mcmc") {
     val mh = ArbitraryMetropolisHastings(logLikelihood _, (_:State) => proposal, (_:State,_:State) => 0.0, A, burnIn = 10000, dropCount=DROP_COUNT)
@@ -56,7 +56,7 @@ class metropolisTest extends FunSuite {
 
   def skewedProposal(x: State) = rand.choose(Seq(A,A,B,C).filter(_ != x) )
 
-  def logSkewedTransitionProbability(start: State, end: State) = (start, end) match {
+  def logSkewedTransitionProbability(start: State, end: State) = (start,end) match {
     case (a,b) if (a == b) => ???
     case (A,_) => math.log(0.5)
     case (_,A) => math.log(2.0/3.0)
@@ -79,5 +79,35 @@ class metropolisTest extends FunSuite {
     assert(math.abs(aCount / bCount - 3) < TOLERANCE)
     assert(math.abs(bCount / cCount - 2) < TOLERANCE)
   }
+
+  test("ArbitraryMetropolisHastings for a Gamma with a symmetric proposal") {
+    import breeze.numerics._
+    import breeze.linalg._
+    val mh = ArbitraryMetropolisHastings(Gamma(2.0, 1.0/3).logPdf, 
+      (x: Double) => Gaussian(x, 1.0), 
+      (x: Double, xp: Double) => Gaussian(x, 1.0).logPdf(xp), 1.0)
+    val sit = mh.samples
+    val its=sit.take(NUM_TESTS).toArray
+    val itsv=DenseVector[Double](its)
+    val mav = breeze.stats.meanAndVariance(itsv)
+    assert(abs(mav.mean-2.0/3) < TOLERANCE)
+    assert(abs(mav.variance-2.0/9) < TOLERANCE)
+  }
+
+  test("ArbitraryMetropolisHastings for a Gamma with a non-symmetric proposal") {
+    import breeze.numerics._
+    import breeze.linalg._
+    val mh = ArbitraryMetropolisHastings(Gamma(2.0, 1.0/3).logPdf, 
+      (x: Double) => Gaussian(x, 1.0+x), 
+      (x: Double, xp: Double) => Gaussian(x, 1.0+x).logPdf(xp), 1.0)
+    val sit = mh.samples
+    val its=sit.take(NUM_TESTS).toArray
+    val itsv=DenseVector[Double](its)
+    val mav = breeze.stats.meanAndVariance(itsv)
+    assert(abs(mav.mean-2.0/3) < TOLERANCE)
+    assert(abs(mav.variance-2.0/9) < TOLERANCE)
+  }
+
+
 
 }


### PR DESCRIPTION
Various minor fixes and some new tests relating to M-H based MCMC.
Fixed bugs in acceptance probabilities for non-symmetric kernels, and also switched to accepting proposals based on log acceptance ratio, in order to prevent numerical underflow on exponentiation of small log ratios.
Also added some tests for MCMC code.
Fixed both the MarkovChain._ code and stuccio's alternative mcmc._ code. Both had problems/issues.

This addresses issue #511 
