### PR TITLE
Gaussian.probability returns negative probability

### DIFF
--- a/math/src/main/scala/breeze/stats/distributions/Gaussian.scala
+++ b/math/src/main/scala/breeze/stats/distributions/Gaussian.scala
@@ -35,9 +35,18 @@ case class Gaussian(mu: Double, sigma: Double)(implicit rand: RandBasis = Rand)
 
   override def toString() =  "Gaussian(" + mu + ", " + sigma + ")"
 
+  /**
+    * Computes the probability that a Gaussian variable Z is within the interval [x, y].
+    * This probaility is computed as P[Z < y] - P[Z < x].
+    * @param x lower-end of the interval
+    * @param y upper-end of the interval
+    * @return probability that the Gaussian random variable Z lies in the interval [x, y]
+    */
+  override def probability(x: Double, y: Double): Double = {
+    require(x <= y, "Undefined probability: lower-end of the interval should be smaller than its upper-end")
+    cdf(y) - cdf(x)
+  }
 
-  // obviously could be more efficient, but eh.
-  override def probability(x: Double, y: Double): Double = cdf(y) - cdf(x)
 
   /**
   * Computes the inverse cdf of the p-value for this gaussian.

--- a/math/src/main/scala/breeze/stats/distributions/Gaussian.scala
+++ b/math/src/main/scala/breeze/stats/distributions/Gaussian.scala
@@ -37,7 +37,7 @@ case class Gaussian(mu: Double, sigma: Double)(implicit rand: RandBasis = Rand)
 
   /**
     * Computes the probability that a Gaussian variable Z is within the interval [x, y].
-    * This probaility is computed as P[Z < y] - P[Z < x].
+    * This probability is computed as P[Z < y] - P[Z < x].
     * @param x lower-end of the interval
     * @param y upper-end of the interval
     * @return probability that the Gaussian random variable Z lies in the interval [x, y]

--- a/math/src/test/scala/breeze/stats/distributions/GaussianTest.scala
+++ b/math/src/test/scala/breeze/stats/distributions/GaussianTest.scala
@@ -57,6 +57,12 @@ class GaussianTest extends FunSuite with Checkers with UnivariateContinuousDistr
     assert(new Gaussian(0,1).unnormalizedLogPdf(1.0) === -0.5)
   }
 
+  test ("Gaussian.probability throws an exception when evluating 1.0 < N(0, 1) < 0.0") {
+    val thrown = intercept[IllegalArgumentException] {
+      new Gaussian(0, 1).probability(1.0, 0.0)
+    }
+  }
+
   override val VARIANCE_TOLERANCE: Double = 9E-2
 
   implicit def arbDistr: Arbitrary[Distr] = Arbitrary {

--- a/math/src/test/scala/breeze/stats/distributions/GaussianTest.scala
+++ b/math/src/test/scala/breeze/stats/distributions/GaussianTest.scala
@@ -57,7 +57,7 @@ class GaussianTest extends FunSuite with Checkers with UnivariateContinuousDistr
     assert(new Gaussian(0,1).unnormalizedLogPdf(1.0) === -0.5)
   }
 
-  test ("Gaussian.probability throws an exception when evluating 1.0 < N(0, 1) < 0.0") {
+  test ("Gaussian.probability throws an exception when evaluating 1.0 < N(0, 1) < 0.0") {
     val thrown = intercept[IllegalArgumentException] {
       new Gaussian(0, 1).probability(1.0, 0.0)
     }


### PR DESCRIPTION
The function  `Gaussian.probability(x, y)` returns a negative probability when x is larger than y. 

This comes from the fact that the probability P[x =< Z <= y], computed as P[Z <= y] - P[Z <= x],  is defined only if x <= y. 

I added a `require` statement that checks if the arguments given are valid.