### PR TITLE
Fixed two issues with hashCode/equals in SparseVector

### DIFF
--- a/math/src/main/scala/breeze/linalg/SparseVector.scala
+++ b/math/src/main/scala/breeze/linalg/SparseVector.scala
@@ -90,7 +90,8 @@ class SparseVector[@spec(Double, Int, Float, Long) V](val array: SparseArray[V])
   /** This is always assumed to be equal to 0, for now. */
   def default: V = zero.zero
 
-  override def equals(p1: Any) = p1 match {
+  override def equals(other: Any) = other match {
+    case x: SparseVector[_] => this.array == x.array
     case x: Vector[_] =>
         this.length == x.length &&
           (valuesIterator sameElements x.valuesIterator)

--- a/math/src/test/scala/breeze/collection/mutable/SparseArrayTest.scala
+++ b/math/src/test/scala/breeze/collection/mutable/SparseArrayTest.scala
@@ -16,6 +16,7 @@ package breeze.collection.mutable
  limitations under the License.
 */
 
+import breeze.linalg.SparseVector
 import org.scalatest._
 import org.scalatest.junit._
 import org.scalatest.prop._
@@ -50,5 +51,20 @@ class SparseArrayTest extends FunSuite with Checkers {
     assert(y.filter(_ > 0).toList === List(1))
     assert(y.filter(_ >= 0).toList === List(0,1,0,0))
   }
-}
 
+  test("equals") {
+    val x = SparseArray.create(1024)(42 -> 100500, 24 -> 500100)
+    assert(x === x)
+    assert(x === SparseArray.create(1024)(42 -> 100500, 24 -> 500100))
+
+    assert(x !== OpenAddressHashArray[Int](x.toArray:_*))
+    assert(x !== SparseArray.create(128)(42 -> 100500, 24 -> 500100))
+    assert(x !== SparseArray.create(1024)(42 -> 42, 24 -> 24))
+  }
+
+  test("equals is O(activeSize)") {
+    val v = SparseVector(Int.MaxValue)(42 -> 100500)
+    val u = SparseVector(Int.MaxValue)(42 -> 100500)
+    assert(u === v)
+  }
+}


### PR DESCRIPTION
1. `SparseVector` defined no `hashCode` and therefore violated the hashCode/equals contract.
2. sparse/sparse comparisons worked in O(size) instead of O(activeSize).