### PR TITLE
Fix lbfgsb linesearch out of bound and findAlpha method

### DIFF
--- a/math/src/main/scala/breeze/optimize/LBFGSB.scala
+++ b/math/src/main/scala/breeze/optimize/LBFGSB.scala
@@ -101,7 +101,8 @@ class LBFGSB(lowerBounds: DenseVector[Double],
       i += 1
     }
 
-    wolfeRuleSearch.minimizeWithBound(ff, 1.0, minStepBound)
+    val initStep = if (minStepBound < 1.0) minStepBound else 1.0
+    wolfeRuleSearch.minimizeWithBound(ff, initStep, minStepBound)
   }
 
   override protected def takeStep(state: State, dir: DenseVector[Double], stepSize: Double) = {

--- a/math/src/main/scala/breeze/optimize/LBFGSB.scala
+++ b/math/src/main/scala/breeze/optimize/LBFGSB.scala
@@ -17,9 +17,10 @@ package breeze.optimize
 
 import breeze.linalg.{DenseMatrix, DenseVector}
 import breeze.linalg._
-import breeze.optimize.FirstOrderMinimizer.{State, ProjectedStepConverged, ConvergenceCheck}
+import breeze.optimize.FirstOrderMinimizer.{ConvergenceCheck, ProjectedStepConverged, State}
 import breeze.util.SerializableLogging
 import breeze.util.Implicits._
+import spire.syntax.cfor._
 
 /**
  * This algorithm is refered the paper
@@ -65,10 +66,12 @@ class LBFGSB(lowerBounds: DenseVector[Double],
 
     //step2:compute the cauchy point by algorithm CP
     val (cauchyPoint, c) = getGeneralizedCauchyPoint(state.history, x, g)
+    adjustWithinBound(cauchyPoint)
 
     val dirk = if(0 == state.iter) cauchyPoint - x else  {
       //step3:compute a search direction d_k by the primal method
       val subspaceMin = subspaceMinimization(state.history, cauchyPoint, x, c, g)
+      adjustWithinBound(subspaceMin)
       subspaceMin - x
     };
 
@@ -93,7 +96,7 @@ class LBFGSB(lowerBounds: DenseVector[Double],
       if (dir != 0.0) {
         val bound = if (dir < 0.0) lowerBounds(i) else upperBounds(i)
         val stepBound = (bound - state.x(i)) / dir
-        assert(stepBound >= 0.0)
+        assert(stepBound > 0.0)
         if (stepBound < minStepBound) {
           minStepBound = stepBound
         }
@@ -101,23 +104,24 @@ class LBFGSB(lowerBounds: DenseVector[Double],
       i += 1
     }
 
-    val initStep = if (minStepBound < 1.0) minStepBound else 1.0
-    wolfeRuleSearch.minimizeWithBound(ff, initStep, minStepBound)
+    wolfeRuleSearch.minimizeWithBound(ff, 1.0, minStepBound)
   }
 
   override protected def takeStep(state: State, dir: DenseVector[Double], stepSize: Double) = {
     val newX = state.x + (dir :* stepSize)
-    var i = 0
-    while (i < newX.length) {
-      if (newX(i) > upperBounds(i)) {
-        newX(i) = upperBounds(i)
-      }
-      if (newX(i) < lowerBounds(i)) {
-        newX(i) = lowerBounds(i)
-      }
-      i += 1
-    }
+    adjustWithinBound(newX)
     newX
+  }
+
+  def adjustWithinBound(point: DenseVector[Double]): Unit = {
+    cforRange(0 until point.length) { i =>
+      if (point(i) > upperBounds(i)) {
+        point(i) = upperBounds(i)
+      }
+      if (point(i) < lowerBounds(i)) {
+        point(i) = lowerBounds(i)
+      }
+    }
   }
 
   private def initialize(f: DiffFunction[DenseVector[Double]], x0: DenseVector[Double]) = {
@@ -214,16 +218,17 @@ class LBFGSB(lowerBounds: DenseVector[Double],
    * @param freeVarIndex
    * @return starAlpha = max{a : a <= 1 and  l_i-xc_i <= a*d_i <= u_i-xc_i}
    */
-  protected def findAlpha(xCauchy:DenseVector[Double], du:Vector[Double], freeVarIndex:Array[Int]) = {
+  protected def findAlpha(xCauchy: DenseVector[Double], du: Vector[Double],
+                                   freeVarIndex: Array[Int]) = {
     var starAlpha = 1.0
-    for((vIdx, i) <- freeVarIndex.zipWithIndex) {
-      starAlpha = if (0 < du(i)) {
-        math.max(starAlpha, math.min(upperBounds(vIdx) - xCauchy(vIdx) / du(i), 1.0))
-      } else {
-        math.max(starAlpha, math.min(lowerBounds(vIdx) - xCauchy(vIdx) / du(i), 1.0))
+    for ((vIdx, i) <- freeVarIndex.zipWithIndex) {
+      if (0 < du(i)) {
+        starAlpha = math.min(starAlpha, (upperBounds(vIdx) - xCauchy(vIdx)) / du(i))
+      } else if (0 > du(i)) {
+        starAlpha = math.min(starAlpha, (lowerBounds(vIdx) - xCauchy(vIdx)) / du(i))
       }
     }
-
+    assert(starAlpha >= 0.0 && starAlpha <= 1.0)
     starAlpha
   }
 

--- a/math/src/main/scala/breeze/optimize/StrongWolfe.scala
+++ b/math/src/main/scala/breeze/optimize/StrongWolfe.scala
@@ -58,12 +58,18 @@ class StrongWolfeLineSearch(maxZoomIter: Int, maxLineSearchIter: Int) extends Cu
   val c1 = 1e-4
   val c2 = 0.9
 
+  def minimize(f: DiffFunction[Double], init: Double = 1.0): Double = {
+    minimizeWithBound(f, init = 1.0, bound = Double.PositiveInfinity)
+  }
+
   /**
    * Performs a line search on the function f, returning a point satisfying
    * the Strong Wolfe conditions. Based on the line search detailed in
    * Nocedal & Wright Numerical Optimization p58.
    */
-  def minimize(f: DiffFunction[Double], init: Double = 1.0):Double = {
+  def minimizeWithBound(f: DiffFunction[Double], init: Double = 1.0, bound: Double = 1.0): Double = {
+
+    require(init <= bound, "init value should <= bound")
 
     def phi(t: Double): Bracket = {
       val (pval, pdd) = f.calculate(t)
@@ -171,8 +177,17 @@ class StrongWolfeLineSearch(maxZoomIter: Int, maxLineSearchIter: Int) extends Cu
         }
 
         low = c
-        t *= 1.5
-        logger.debug("Sufficent Decrease condition but not curvature condition satisfied. Increased t to: " + t)
+        if (t == bound) {
+          logger.debug("Reach bound, satisfy sufficent decrease condition," +
+            " but not curvature condition satisfied.")
+          return bound
+        } else {
+          t *= 1.5
+          if (t > bound) {
+            t = bound
+          }
+          logger.debug("Sufficent Decrease condition but not curvature condition satisfied. Increased t to: " + t)
+        }
       }
     }
 

--- a/math/src/main/scala/breeze/optimize/StrongWolfe.scala
+++ b/math/src/main/scala/breeze/optimize/StrongWolfe.scala
@@ -63,9 +63,10 @@ class StrongWolfeLineSearch(maxZoomIter: Int, maxLineSearchIter: Int) extends Cu
   }
 
   /**
-   * Performs a line search on the function f, returning a point satisfying
-   * the Strong Wolfe conditions. Based on the line search detailed in
-   * Nocedal & Wright Numerical Optimization p58.
+   * Performs a line search on the function f with bound, returning a point satisfying
+   * the Strong Wolfe conditions OR satisfying sufficient decrease condition and hit bound.
+   * Based on the line search detailed in Nocedal & Wright Numerical Optimization p58.
+   * BUT add some modification for bound checking.
    */
   def minimizeWithBound(f: DiffFunction[Double], init: Double = 1.0, bound: Double = 1.0): Double = {
 

--- a/math/src/test/scala/breeze/optimize/LBFGSBTest.scala
+++ b/math/src/test/scala/breeze/optimize/LBFGSBTest.scala
@@ -97,4 +97,23 @@ class LBFGSBTest extends OptimizeTestBase{
     assert(ures.value < res.value)
   }
 
+  test("issue 572") {
+    val solver = new LBFGSB(DenseVector[Double](1E-12), DenseVector[Double](Double.MaxValue))
+
+    val f = new DiffFunction[DenseVector[Double]] {
+      override def calculate(x: DenseVector[Double]): (Double, DenseVector[Double]) = {
+        val cost = x(0) + 1.0/x(0)
+        val grad = DenseVector(1.0 - 1.0/(x(0)*x(0)))
+        (cost, grad)
+      }
+    }
+
+    val nearX0 = DenseVector[Double](1.5)
+    val nearRes = solver.minimizeAndReturnState(f, nearX0)
+    assert(abs(nearRes.x(0) - 1.0) < EPS)
+
+    val farX0 = DenseVector[Double](1500)
+    val farRes = solver.minimizeAndReturnState(f, farX0)
+    assert(abs(farRes.x(0) - 1.0) < EPS)
+  }
 }


### PR DESCRIPTION
# What to solve
After a deep check to the LBFGS-B in breeze, I found two serious bug in LBFGS-B:
- line search is wrong in this implementation. 
- `LBFGSB.findAlpha` method is also wrong.

# Fix Line search with bound
According to the LBFGS-B paper
http://users.iems.northwestern.edu/~nocedal/PDFfiles/limited.pdf
The line search in LBFGS-B should be restricted in the bound, but the implementation in breeze do not,
this will cause the optimizer run out of bound, it will cause wrong result or cause line search fail, in some case.
This is the root cause of issue #572, and a series of features is blocking because of this bug:  
- Huber loss: https://github.com/apache/spark/pull/14326
- Bounded LiR: https://github.com/apache/spark/pull/17360
- Bounded LoR: https://issues.apache.org/jira/browse/SPARK-20047

So that it should be fixed ASAP.  
cc @yanboliang 

## Strong wolfe line search with bound restriction
As mentioned in paper, the best linesearch method for LBFGS-B is strong wolfe line search with bound restriction, this require some modification based on `StrongWolfeLineSearch` in breeze:

### modified strong wolfe condition with bound
We know that strong wolfe condition is to satisfy **sufficient decrease condition** and **curvature condition**, BUT according to the paper, the strong wolfe line search in LBFGS-B, the condition should be modified as following:
- satisfy **sufficient decrease condition**
- satisfy **curvature condition** OR **new point X(k + 1) hit the bound**

### Algorithm for strong wolfe condition with bound
Without bound, we already have the following algos (Nodecal & Wright Numerical Optimization p58)
![lbfgsb-1](https://cloud.githubusercontent.com/assets/19235986/24540092/43cbda84-1624-11e7-929b-2d2cd2e1af1c.png)
So that, with bound, we can modify this algo into following:
![lbfgsb-2](https://cloud.githubusercontent.com/assets/19235986/24541690/0f87c6fa-162b-11e7-8c68-6dcb2d2599e7.png)

## modification in LBFGS-B
- In method `determineStepSize`, first calculate the max step size which won't exceed bound box, then use it as the step bound, call `StrongWolfeLineSearch.minimizeWithBound`
- override `takeStep` method, in this method check whether the `newX` exceed bound and correct it. (This is used to avoid numerical error that cause the `newX` run out of bound)

# Fix `findAlpha` method
Unfortunately, the `findAlpha` method here is also wrong, the wrong implementation cause the `subspaceMin` point walk out of bound and so that in some case it will also cause the algos crash.
I trace to the code here through several failed testcases with `Huber loss`.
In summary, there are at least 2 mistakes in this method, let me explain what the method should do first:

find the maximum `alpha`, satisfiy `0.0 <= alpha <= 1.0`, and, for each dimension `i`, should satisfy:
```
lowerBound_i - xCauchy_i <= alpha * du_i <= upperBound_i - xCauchy_i
```

`xCauchy` is the Cauchy point inside the bound box which will satisfy
```
lowerBound_i - xCauchy_i <= 0
upperBound_i - xCauchy_i >= 0
```
and `du` is the direction vector (details please refer to the paper), the key point is ,  **for each `i`, the condition above should be satisfied**, so that the `subspace minimum point` computed will be restricted in the bound box.

So that the algo to find the maximum alpha should be:
```
minimize i: 0 -> dimensionSize  {
  if (du_i < 0) (lowerBound_i - xCauchy_i) / du_i
  else if (du_i > 0) (upperBound_i - xCauchy_i) / du_i
  else Double.Infinity
}
```
Note that we should handle the case `du_i == 0` carefully, otherwise it may generate `NaN` in computation and will cause the whole algo crash.

Then we can check the implementation in breeze, the logic in `findAlpha` is wrong. The place where it should use `math.min` it use `math.max`. And the code write `(ub_i - xc_i) / du_i` to be the wrong code `ub_i - xc_i / du_i`

The second mistake in `findAlpha` is that it do not handle the case that components of `du` is zero. This may cause computation run into `NaN`. We should skip the zero components of `du`.

# Numerical error handling
In theory, the `cauchy point`, the `subspaceMin point`, the `X` point, in the computation, should all be restricted in the bound box. BUT because of floating point error, it may slightly exceed the bound, so I add a `adjustWithinBound` method to correct it. So that it can avoid the point step out of bound which may cause other bugs.

# Test
The following typical algos have been tested:
- huber loss regression
- bounded LOR
- bounded LIR
