### PR TITLE
Inlined 'Array.tabulate' into 'DenseVector.tabulate'

### DIFF
--- a/math/src/main/scala/breeze/linalg/Vector.scala
+++ b/math/src/main/scala/breeze/linalg/Vector.scala
@@ -878,7 +878,15 @@ trait VectorConstructors[Vec[T]<:Vector[T]] {
    * @return
    */
   def tabulate[@spec(Double, Int, Float, Long) V:ClassTag](size: Int)(f: Int=>V): Vec[V] = {
-    apply(Array.tabulate(size)(f))
+    val b = ArrayBuilder.make[V]()
+    b.sizeHint(size)
+    var i = 0
+    while (i < size) {
+      b += f(i)
+      i += 1
+    }
+
+    apply(b.result)
   }
 
   /**


### PR DESCRIPTION
This allows to avoid boxing in the argument and return type of `f`. You  might be thinking "Boxing? but it is specialized!". Turns out `Array.tabulate` is not, therefore it would call a non-specialized version of the `Function1` trait, which would effectively box both
the index and the produced value.

---

I've used the following to validate the PR

```scala
object Test {
  def main(args: Array[String]): Unit = {
    while (true) {
      DenseVector.tabulate(1000)(i => i)
    }
  }
}
```

Here's the output of `jmap -histo` for the old version

```
 num     #instances         #bytes  class name
----------------------------------------------
   1:       2079104       33265664  java.lang.Integer
   2:          1923       10381408  [I
   3:          5795         593752  [C
   4:          1760         192776  java.lang.Class
   5:          5778         138672  java.lang.String
   6:          2536         121728  java.util.HashMap
   7:          2637          84384  java.util.HashMap$Node
```

and for the new one

```
 num     #instances         #bytes  class name
----------------------------------------------
   1:         21564       85093768  [I
   2:         20804         832160  breeze.linalg.DenseVector$mcI$sp
   3:          5792         593720  [C
   4:         20805         499320  scala.collection.mutable.ArrayBuilder$ofInt
   5:          1758         192560  java.lang.Class
   6:          5776         138624  java.lang.String
   7:          2536         121728  java.util.HashMap
```