### PR TITLE
use JavaConverters instead of JavaConversions

### DIFF
--- a/math/src/main/scala/breeze/util/TopK.scala
+++ b/math/src/main/scala/breeze/util/TopK.scala
@@ -13,10 +13,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-package breeze.util;
+package breeze.util
 
-import java.util.TreeSet;
-import scala.collection.JavaConverters._;
+import java.util.TreeSet
+import scala.collection.JavaConverters._
 
 /**
  * A Top-K queue keeps a list of the top K elements seen so far as ordered
@@ -24,37 +24,37 @@ import scala.collection.JavaConverters._;
  */
 class TopK[T](k : Int)(implicit ord : Ordering[T]) extends Iterable[T] {
 
-  private val keys = new TreeSet[T](ord);
+  private val keys = new TreeSet[T](ord)
 
   def +=(e : T) = {
     if (keys.size < k) {
-      keys.add(e);
+      keys.add(e)
     } else if (keys.size > 0 && ord.lt(keys.first, e) && !keys.contains(e)) {
-      keys.remove(keys.first);
-      keys.add(e);
+      keys.remove(keys.first)
+      keys.add(e)
     }
   }
 
   override def iterator : Iterator[T] =
-    keys.descendingIterator.asScala;
+    keys.descendingIterator.asScala
 
   override def size =
-    keys.size;
+    keys.size
 }
 
 object TopK {
   def apply[T](k : Int, items : TraversableOnce[T])(implicit ord : Ordering[T]) : TopK[T] = {
-    val topk = new TopK[T](k)(ord);
-    items.foreach(topk += _);
-    topk;
+    val topk = new TopK[T](k)(ord)
+    items.foreach(topk += _)
+    topk
   }
 
   def apply[T,U](k : Int, items : TraversableOnce[T], scoreFn : (T => U))
   (implicit uord : Ordering[U]) : TopK[T] = {
     implicit val ord = new Ordering[T] {
-      override def compare(x : T, y : T) = uord.compare(scoreFn(x), scoreFn(y));
-    };
-    apply(k, items)(ord);
+      override def compare(x : T, y : T) = uord.compare(scoreFn(x), scoreFn(y))
+    }
+    apply(k, items)(ord)
   }
 }
 
@@ -63,24 +63,24 @@ object TopK {
  */
 class TopKIterable[T](val self : Iterable[T]) {
   def topk(k : Int)(implicit ord : Ordering[T]) : TopK[T] =
-    TopK(k, self);
+    TopK(k, self)
 
   def topk[U](k : Int, scoreFn : (T => U))(implicit uord : Ordering[U]) : TopK[T] =
-    TopK(k, self, scoreFn)(uord);
+    TopK(k, self, scoreFn)(uord)
 }
 
 class TopKIterator[T](val self : Iterator[T]) {
   def topk(k : Int)(implicit ord : Ordering[T]) : TopK[T] =
-    TopK(k, self);
+    TopK(k, self)
 
   def topk[U](k : Int, scoreFn : (T => U))(implicit uord : Ordering[U]) : TopK[T] =
-    TopK(k, self, scoreFn)(uord);
+    TopK(k, self, scoreFn)(uord)
 }
 
 object TopKImplicits {
   implicit def iTopKIterable[T](iterable : Iterable[T]) =
-    new TopKIterable(iterable);
+    new TopKIterable(iterable)
 
   implicit def iTopKIterator[T](iterator : Iterator[T]) =
-    new TopKIterator(iterator);
+    new TopKIterator(iterator)
 }

--- a/math/src/main/scala/breeze/util/TopK.scala
+++ b/math/src/main/scala/breeze/util/TopK.scala
@@ -16,7 +16,7 @@
 package breeze.util;
 
 import java.util.TreeSet;
-import scala.collection.JavaConversions._;
+import scala.collection.JavaConverters._;
 
 /**
  * A Top-K queue keeps a list of the top K elements seen so far as ordered
@@ -36,7 +36,7 @@ class TopK[T](k : Int)(implicit ord : Ordering[T]) extends Iterable[T] {
   }
 
   override def iterator : Iterator[T] =
-    keys.descendingIterator;
+    keys.descendingIterator.asScala;
 
   override def size =
     keys.size;

--- a/math/src/main/scala/breeze/util/TopK.scala
+++ b/math/src/main/scala/breeze/util/TopK.scala
@@ -26,13 +26,14 @@ class TopK[T](k: Int)(implicit ord: Ordering[T]) extends Iterable[T] {
 
   private val keys = new TreeSet[T](ord)
 
-  def +=(e: T): AnyVal = {
+  def +=(e: T): this.type = {
     if (keys.size < k) {
       keys.add(e)
     } else if (keys.size > 0 && ord.lt(keys.first, e) && !keys.contains(e)) {
       keys.remove(keys.first)
       keys.add(e)
     }
+    this
   }
 
   override def iterator: Iterator[T] =

--- a/math/src/main/scala/breeze/util/TopK.scala
+++ b/math/src/main/scala/breeze/util/TopK.scala
@@ -22,11 +22,11 @@ import scala.collection.JavaConverters._
  * A Top-K queue keeps a list of the top K elements seen so far as ordered
  * by the given comparator.
  */
-class TopK[T](k : Int)(implicit ord : Ordering[T]) extends Iterable[T] {
+class TopK[T](k: Int)(implicit ord: Ordering[T]) extends Iterable[T] {
 
   private val keys = new TreeSet[T](ord)
 
-  def +=(e : T) = {
+  def +=(e: T) = {
     if (keys.size < k) {
       keys.add(e)
     } else if (keys.size > 0 && ord.lt(keys.first, e) && !keys.contains(e)) {
@@ -35,7 +35,7 @@ class TopK[T](k : Int)(implicit ord : Ordering[T]) extends Iterable[T] {
     }
   }
 
-  override def iterator : Iterator[T] =
+  override def iterator: Iterator[T] =
     keys.descendingIterator.asScala
 
   override def size =
@@ -43,16 +43,15 @@ class TopK[T](k : Int)(implicit ord : Ordering[T]) extends Iterable[T] {
 }
 
 object TopK {
-  def apply[T](k : Int, items : TraversableOnce[T])(implicit ord : Ordering[T]) : TopK[T] = {
+  def apply[T](k: Int, items: TraversableOnce[T])(implicit ord: Ordering[T]): TopK[T] = {
     val topk = new TopK[T](k)(ord)
     items.foreach(topk += _)
     topk
   }
 
-  def apply[T,U](k : Int, items : TraversableOnce[T], scoreFn : (T => U))
-  (implicit uord : Ordering[U]) : TopK[T] = {
+  def apply[T, U](k: Int, items: TraversableOnce[T], scoreFn: T => U)(implicit uord: Ordering[U]): TopK[T] = {
     implicit val ord = new Ordering[T] {
-      override def compare(x : T, y : T) = uord.compare(scoreFn(x), scoreFn(y))
+      override def compare(x: T, y: T) = uord.compare(scoreFn(x), scoreFn(y))
     }
     apply(k, items)(ord)
   }
@@ -61,26 +60,26 @@ object TopK {
 /**
  * A rich iterable extension that adds the topk method.
  */
-class TopKIterable[T](val self : Iterable[T]) {
-  def topk(k : Int)(implicit ord : Ordering[T]) : TopK[T] =
+class TopKIterable[T](val self: Iterable[T]) {
+  def topk(k: Int)(implicit ord: Ordering[T]): TopK[T] =
     TopK(k, self)
 
-  def topk[U](k : Int, scoreFn : (T => U))(implicit uord : Ordering[U]) : TopK[T] =
+  def topk[U](k: Int, scoreFn: T => U)(implicit uord: Ordering[U]): TopK[T] =
     TopK(k, self, scoreFn)(uord)
 }
 
-class TopKIterator[T](val self : Iterator[T]) {
-  def topk(k : Int)(implicit ord : Ordering[T]) : TopK[T] =
+class TopKIterator[T](val self: Iterator[T]) {
+  def topk(k: Int)(implicit ord: Ordering[T]): TopK[T] =
     TopK(k, self)
 
-  def topk[U](k : Int, scoreFn : (T => U))(implicit uord : Ordering[U]) : TopK[T] =
+  def topk[U](k: Int, scoreFn: T => U)(implicit uord: Ordering[U]): TopK[T] =
     TopK(k, self, scoreFn)(uord)
 }
 
 object TopKImplicits {
-  implicit def iTopKIterable[T](iterable : Iterable[T]) =
+  implicit def iTopKIterable[T](iterable: Iterable[T]) =
     new TopKIterable(iterable)
 
-  implicit def iTopKIterator[T](iterator : Iterator[T]) =
+  implicit def iTopKIterator[T](iterator: Iterator[T]) =
     new TopKIterator(iterator)
 }

--- a/math/src/main/scala/breeze/util/TopK.scala
+++ b/math/src/main/scala/breeze/util/TopK.scala
@@ -26,7 +26,7 @@ class TopK[T](k: Int)(implicit ord: Ordering[T]) extends Iterable[T] {
 
   private val keys = new TreeSet[T](ord)
 
-  def +=(e: T) = {
+  def +=(e: T): AnyVal = {
     if (keys.size < k) {
       keys.add(e)
     } else if (keys.size > 0 && ord.lt(keys.first, e) && !keys.contains(e)) {
@@ -38,7 +38,7 @@ class TopK[T](k: Int)(implicit ord: Ordering[T]) extends Iterable[T] {
   override def iterator: Iterator[T] =
     keys.descendingIterator.asScala
 
-  override def size =
+  override def size: Int =
     keys.size
 }
 
@@ -51,7 +51,7 @@ object TopK {
 
   def apply[T, U](k: Int, items: TraversableOnce[T], scoreFn: T => U)(implicit uord: Ordering[U]): TopK[T] = {
     implicit val ord = new Ordering[T] {
-      override def compare(x: T, y: T) = uord.compare(scoreFn(x), scoreFn(y))
+      override def compare(x: T, y: T): Int = uord.compare(scoreFn(x), scoreFn(y))
     }
     apply(k, items)(ord)
   }
@@ -77,9 +77,9 @@ class TopKIterator[T](val self: Iterator[T]) {
 }
 
 object TopKImplicits {
-  implicit def iTopKIterable[T](iterable: Iterable[T]) =
+  implicit def iTopKIterable[T](iterable: Iterable[T]): TopKIterable[T] =
     new TopKIterable(iterable)
 
-  implicit def iTopKIterator[T](iterator: Iterator[T]) =
+  implicit def iTopKIterator[T](iterator: Iterator[T]): TopKIterator[T] =
     new TopKIterator(iterator)
 }


### PR DESCRIPTION
Replace JavaConversions with JavaConverters because JavaConversions is deprecated since Scala 2.12.
Some refactoring is also added.