### PR TITLE
remove some deprecated warnings

### DIFF
--- a/macros/src/main/scala/breeze/macros/arityize.scala
+++ b/macros/src/main/scala/breeze/macros/arityize.scala
@@ -25,10 +25,10 @@ object arityize {
         val maxOrder: Int = extractOrder(c)
 
         val results = for(order <- 1 to maxOrder) yield {
-          val bindings = Map(name.encoded -> order)
+          val bindings = Map(name.encodedName.toString -> order)
           val newTemplate = Template(impl.parents, impl.self, impl.body.flatMap(x => expandArity(c, order, bindings)(x)))
           val newTargs = targs.flatMap(arg => expandTypeDef(c, order, bindings)(arg))
-          ClassDef(mods, newTypeName(name.encoded + order), newTargs, newTemplate)
+          ClassDef(mods, newTypeName(name.encodedName.toString + order), newTargs, newTemplate)
         }
 
         val ret = c.Expr(Block(results.toList, Literal(Constant(()))))
@@ -37,13 +37,13 @@ object arityize {
         val maxOrder: Int = extractOrder(c)
 
         val results = for(order <- 1 to maxOrder) yield {
-          val bindings = Map(name.encoded -> order)
+          val bindings = Map(name.encodedName.toString -> order)
 
           val newImpl = expandArity(c, order, bindings)(impl).head
           val newVargs = vargs.map(_.flatMap(arg => expandValDef(c, order, bindings)(arg)))
           val newTargs = targs.flatMap(arg => expandTypeDef(c, order, bindings)(arg))
           val newRet = expandArity(c, order, bindings)(tpt).head
-          DefDef(mods, newTermName(name.encoded + order), newTargs, newVargs, newRet, newImpl)
+          DefDef(mods, newTermName(name.encodedName.toString + order), newTargs, newVargs, newRet, newImpl)
         }
 
         val ret = c.Expr(Block(results.toList, Literal(Constant(()))))
@@ -77,10 +77,10 @@ object arityize {
         ann match {
           case q"new arityize.relative($sym)" =>
             tree match {
-              case Ident(nme) if nme.isTypeName => Seq(Ident(newTypeName(nme.encoded + bindings(sym.toString))))
-              case Ident(nme) if nme.isTermName => Seq(Ident(newTermName(nme.encoded + bindings(sym.toString))))
+              case Ident(nme) if nme.isTypeName => Seq(Ident(newTypeName(nme.encodedName.toString + bindings(sym.toString))))
+              case Ident(nme) if nme.isTermName => Seq(Ident(newTermName(nme.encodedName.toString + bindings(sym.toString))))
               case AppliedTypeTree(Ident(nme), targs) =>
-                val newName = Ident(newTypeName(nme.encoded + bindings(sym.toString)))
+                val newName = Ident(newTypeName(nme.encodedName.toString + bindings(sym.toString)))
                 val newTargs = targs.flatMap(arg => expandArity(c, order, bindings)(arg))
                 Seq(AppliedTypeTree(newName, newTargs))
               case _ =>
@@ -90,9 +90,9 @@ object arityize {
           case q"new arityize.replicate()" =>
             tree match {
               case Ident(nme) if nme.isTypeName =>
-                List.tabulate(order){i => Ident(newTypeName(nme.encoded + (i + 1))) }
+                List.tabulate(order){i => Ident(newTypeName(nme.encodedName.toString + (i + 1))) }
               case Ident(nme) if nme.isTermName =>
-                List.tabulate(order){i => Ident(newTermName(nme.encoded + (i + 1))) }
+                List.tabulate(order){i => Ident(newTermName(nme.encodedName.toString + (i + 1))) }
               case _ => ???
             }
           case q"new arityize.repeat()" =>
@@ -109,7 +109,7 @@ object arityize {
         }
       case Block(stats, ret) =>
         Seq(Block(stats.flatMap(st => expandArity(c, order, bindings)(st)), expandArity(c, order, bindings)(ret).last))
-      case Ident(nme) if nme.encoded == "__order__" => Seq(Literal(Constant(order)))
+      case Ident(nme) if nme.encodedName.toString == "__order__" => Seq(Literal(Constant(order)))
       case t@Ident(x) => Seq(t)
       case t@Literal(x) => Seq(t)
       case Apply(who, args) =>
@@ -138,16 +138,16 @@ object arityize {
     import c.mirror.universe._
     if(shouldExpand(c)(vdef.mods)) {
       List.tabulate(order){i =>
-        val newBindings = bindings + (vdef.name.encoded -> (i + 1))
+        val newBindings = bindings + (vdef.name.encodedName.toString -> (i + 1))
 //        println(vdef.tpt + " " + expandArity(c, order, newBindings)(vdef.tpt).head)
-        ValDef(vdef.mods, newTermName(vdef.name.encoded + (i + 1)), expandArity(c, order, newBindings)(vdef.tpt).head, vdef.rhs)
+        ValDef(vdef.mods, newTermName(vdef.name.encodedName.toString + (i + 1)), expandArity(c, order, newBindings)(vdef.tpt).head, vdef.rhs)
       }
     } else {
       shouldRelativize(c)(vdef.mods) match {
         case Some(x) =>
-          val newBindings = bindings + (vdef.name.encoded -> bindings(x))
+          val newBindings = bindings + (vdef.name.encodedName.toString -> bindings(x))
           val newTpt = expandArity(c, order, newBindings)(vdef.tpt).head
-          List(ValDef(vdef.mods, newTermName(vdef.name.encoded + bindings(x)), newTpt, vdef.rhs))
+          List(ValDef(vdef.mods, newTermName(vdef.name.encodedName.toString + bindings(x)), newTpt, vdef.rhs))
         case _ =>
           val newTpt = expandArity(c, order, bindings)(vdef.tpt).head
           List(ValDef(vdef.mods, vdef.name, newTpt, vdef.rhs))
@@ -159,13 +159,13 @@ object arityize {
   def expandTypeDef(c: Context, order: Int, bindings: Map[String, Int])(vdef: c.universe.TypeDef):List[c.universe.TypeDef] = {
     import c.mirror.universe._
     if(shouldExpand(c)(vdef.mods)) {
-      List.tabulate(order)(i => TypeDef(vdef.mods, newTypeName(vdef.name.encoded + (i + 1)), vdef.tparams, vdef.rhs))
+      List.tabulate(order)(i => TypeDef(vdef.mods, newTypeName(vdef.name.encodedName.toString + (i + 1)), vdef.tparams, vdef.rhs))
     } else if(shouldRepeat(c)(vdef.mods)) {
         List.fill(order)(vdef)
     } else {
       shouldRelativize(c)(vdef.mods) match {
         case Some(x) =>
-          List(TypeDef(vdef.mods, newTypeName(vdef.name.encoded + bindings(x)), vdef.tparams, vdef.rhs))
+          List(TypeDef(vdef.mods, newTypeName(vdef.name.encodedName.toString + bindings(x)), vdef.tparams, vdef.rhs))
         case _ =>
           List(vdef)
       }

--- a/macros/src/main/scala/breeze/macros/arityize.scala
+++ b/macros/src/main/scala/breeze/macros/arityize.scala
@@ -1,7 +1,7 @@
 package breeze.macros
 
 import scala.annotation.{StaticAnnotation, Annotation}
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 /**
  * TODO

--- a/macros/src/main/scala/breeze/macros/expand.scala
+++ b/macros/src/main/scala/breeze/macros/expand.scala
@@ -48,9 +48,8 @@ import scala.annotation.{Annotation, StaticAnnotation}
  *@author dlwh
  **/
 class expand extends Annotation with StaticAnnotation {
-  def macroTransform(annottees: Any*):Any = macro expand.expandImpl
+  def macroTransform(annottees: Any*): Any = macro expand.expandImpl
 }
-
 
 object expand {
 
@@ -66,7 +65,6 @@ object expand {
   class valify extends Annotation with StaticAnnotation
   /** \@sequence[T](args) associates the term parameter's values with the type argument indicated. */
   class sequence[T](args: Any*) extends Annotation with StaticAnnotation
-
 
   def expandImpl(c: Context)(annottees: c.Expr[Any]*):c.Expr[Any] = {
     import c.mirror.universe._
@@ -157,8 +155,6 @@ object expand {
     } transform rhs
   }
 
-
-
   /** for a valdef with a [[breeze.macros.expand.sequence]] annotation, converts the sequence of associations to a Map */
   private def solveSequence(context: Context)(v: context.mirror.universe.ValDef, typeMappings: Map[context.Name, List[context.Type]]):(context.Name, Map[context.Type, context.Tree]) = {
     import context.mirror.universe._
@@ -214,7 +210,7 @@ object expand {
     }.flatten.toSeq
   }
 
-    private def checkValify(c: Context)(mods: c.Modifiers) = {
+  private def checkValify(c: Context)(mods: c.Modifiers) = {
     import c.mirror.universe._
     mods.annotations.collectFirst {
         case q"new expand.valify" => true

--- a/macros/src/main/scala/breeze/macros/expand.scala
+++ b/macros/src/main/scala/breeze/macros/expand.scala
@@ -1,6 +1,6 @@
 package breeze.macros
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 import scala.language.experimental.macros
 import scala.annotation.{Annotation, StaticAnnotation}
 

--- a/macros/src/main/scala/breeze/macros/expand.scala
+++ b/macros/src/main/scala/breeze/macros/expand.scala
@@ -185,7 +185,7 @@ object expand {
 
     val mods = td.mods.annotations.collect{ case tree@q"new expand.args(...$args)" =>
       val flatArgs:Seq[Tree] = args.flatten
-      flatArgs.map(c.typeCheck(_)).map{ tree =>
+      flatArgs.map(c.typecheck(_)).map{ tree =>
         try {
           tree.symbol.asModule.companionSymbol.asType.toType
         }  catch {
@@ -210,7 +210,7 @@ object expand {
           for(aa <- args)
             if(aa.length != targs.length)
               c.error(t.pos, "arguments to @exclude does not have the same arity as the type symbols!")
-          args.map(aa => (targs zip aa.map(c.typeCheck(_)).map(_.symbol.asModule.companionSymbol.asType.toType)).toMap)
+          args.map(aa => (targs zip aa.map(c.typecheck(_)).map(_.symbol.asModule.companionSymbol.asType.toType)).toMap)
     }.flatten.toSeq
   }
 

--- a/macros/src/main/scala/breeze/macros/expand.scala
+++ b/macros/src/main/scala/breeze/macros/expand.scala
@@ -94,7 +94,7 @@ object expand {
           val grounded = substitute(c)(typeMap, valExpansions, rhs)
           val newvargs = valsToLeave.filterNot(_.isEmpty).map(_.map(substitute(c)(typeMap, valExpansions, _).asInstanceOf[ValDef]))
           val newtpt = substitute(c)(typeMap, valExpansions, tpt)
-          val newName = newTermName(mkName(c)(name, typeMap))
+          val newName = TermName(mkName(c)(name, typeMap))
           if(shouldValify) {
             if(typesLeftAbstract.nonEmpty)
               c.error(tree.pos, "Can't valify: Not all types were grounded: " + typesLeftAbstract.mkString(", "))
@@ -168,7 +168,7 @@ object expand {
           context.error(x.pos, s"@sequence arguments list does not match the expand.args for $nme2")
         }
         val predef = context.mirror.staticModule("scala.Predef").asModule
-        val missing = Select(Ident(predef), newTermName("???"))
+        val missing = Select(Ident(predef), TermName("???"))
         nme2 -> (typeMappings(nme2) zip args.flatten).toMap.withDefaultValue(missing)
     }
     x.get

--- a/macros/src/main/scala/scalaxy/debug/package.scala
+++ b/macros/src/main/scala/scalaxy/debug/package.scala
@@ -111,7 +111,7 @@ object impl
     def newValDef(name: String, rhs: Tree, tpe: Type = null) = {
       ValDef(
         NoMods,
-        newTermName(c.fresh(name)),
+        TermName(c.fresh(name)),
         TypeTree(Option(tpe).getOrElse(rhs.tpe.normalize)),
         rhs
       )

--- a/macros/src/main/scala/scalaxy/debug/package.scala
+++ b/macros/src/main/scala/scalaxy/debug/package.scala
@@ -24,7 +24,7 @@ import scala.language.experimental.macros
 
 import scala.reflect.ClassTag
 import scala.reflect.NameTransformer.encode
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 package object debug
 {

--- a/macros/src/main/scala/scalaxy/debug/package.scala
+++ b/macros/src/main/scala/scalaxy/debug/package.scala
@@ -131,7 +131,7 @@ object impl
       case _ => false
     }
 
-    val typedCondition = c.typeCheck(condition.tree)//, typeOf[Boolean])
+    val typedCondition = c.typecheck(condition.tree)//, typeOf[Boolean])
     c.Expr[Unit](
       typedCondition match
       {

--- a/macros/src/main/scala/scalaxy/debug/package.scala
+++ b/macros/src/main/scala/scalaxy/debug/package.scala
@@ -22,7 +22,6 @@ package scalaxy
 import scala.language.dynamics
 import scala.language.experimental.macros
 
-import scala.reflect.ClassTag
 import scala.reflect.NameTransformer.encode
 import scala.reflect.macros.whitebox.Context
 

--- a/macros/src/main/scala/scalaxy/debug/package.scala
+++ b/macros/src/main/scala/scalaxy/debug/package.scala
@@ -111,7 +111,7 @@ object impl
     def newValDef(name: String, rhs: Tree, tpe: Type = null) = {
       ValDef(
         NoMods,
-        TermName(c.fresh(name)),
+        TermName(c.freshName(name)),
         TypeTree(Option(tpe).getOrElse(rhs.tpe.normalize)),
         rhs
       )


### PR DESCRIPTION
This PR removes following warnings:

* type Context in package macros is deprecated (since 2.11.0): use blackbox.Context or whitebox.Context instead
* method encoded in class NameApi is deprecated (since 2.11.0): use `encodedName.toString` instead
*  method newTypeName in trait Names is deprecated (since 2.11.0): use TypeName instead
* method newTermName in trait Names is deprecated (since 2.11.0): use TermName instead
* method typeCheck in trait Typers is deprecated (since 2.11.0): use `c.typecheck` instead
* method fresh in trait Names is deprecated (since 2.11.0): use freshName instead