### PR TITLE
Lazily populate dense vectors. 

### DIFF
--- a/math/src/main/scala/breeze/linalg/DenseMatrix.scala
+++ b/math/src/main/scala/breeze/linalg/DenseMatrix.scala
@@ -141,7 +141,7 @@ final class DenseMatrix[@spec(Double, Int, Float, Long) V](private var populator
   lazy val majorStride = populator.majorStride
   lazy val isTranspose = populator.isTranspose
   populator.checkDimensions
-  private def initializeData = {
+  private def initializeDimensions = {
     rows
     cols
     offset
@@ -159,11 +159,18 @@ final class DenseMatrix[@spec(Double, Int, Float, Long) V](private var populator
   /** Creates a matrix with the specified data array and rows. columns inferred automatically */
   def this(rows: Int, data: Array[V], offset: Int) = this(rows, {assert(data.length % rows == 0); data.length/rows}, data, offset)
 
-  lazy val data: Array[V] = {
-    val r = populator.data
-    initializeData
-    populator = null
-    r
+  private var myData: Array[V] = null
+  lazy val data: Array[V] = if (populator == null) {
+    myData
+  } else {
+    this.synchronized {
+      if (populator != null) {
+        myData = populator.data
+        initializeDimensions
+        populator = null
+      }
+    }
+    myData
   }
 
 

--- a/math/src/main/scala/breeze/linalg/functions/diag.scala
+++ b/math/src/main/scala/breeze/linalg/functions/diag.scala
@@ -14,11 +14,19 @@ import breeze.storage.Zero
  */
 object diag extends UFunc with diagLowPrio2 {
 
+  private class VectorDiagonalMatrixPopulator[V:ClassTag:Zero](t: DenseVector[V]) extends DiagonalMatrixPopulator[V](t.size) {
+    override def apply(i: Int, j: Int): V = {
+      if (i == j) {
+        t(i)
+      } else {
+        implicitly[Zero[V]].zero
+      }
+    }
+  }
+
   implicit def diagDVDMImpl[V:ClassTag:Zero]:diag.Impl[DenseVector[V], DenseMatrix[V]] = new diag.Impl[DenseVector[V], DenseMatrix[V]] {
     def apply(t: DenseVector[V]): DenseMatrix[V] = {
-      val r = DenseMatrix.zeros[V](t.length, t.length)
-      diag(r) := t
-      r
+      new DenseMatrix(new VectorDiagonalMatrixPopulator(t))
     }
   }
 


### PR DESCRIPTION
I've been running into issues with code generating too many dense matrices, many of which are not necessary. 

For example, consider this issue: https://github.com/scalanlp/breeze/issues/563 The issue is basically that taking the outer product of two vectors results in storing an NxN matrix (immediately discarded) instead of two N-dimensional vectors. (I've also run into this issue.)

Similarly, an Identity matrix actually requires no storage at all. 

This PR allows a DenseMatrix to be constructed with a `MatrixPopulator` - a class that will construct the data storage only when (if) needed. 

Eventually I'd like to do things like, e.g., resolving #563 by building an `OuterProductMatrixPopulator` and similar things. But since this is a relatively big change, I figured I'd request feedback before doing too much. 