### PR TITLE
Fix strong wolfe line search init value bug

### DIFF
--- a/math/src/main/scala/breeze/optimize/StrongWolfe.scala
+++ b/math/src/main/scala/breeze/optimize/StrongWolfe.scala
@@ -59,7 +59,7 @@ class StrongWolfeLineSearch(maxZoomIter: Int, maxLineSearchIter: Int) extends Cu
   val c2 = 0.9
 
   def minimize(f: DiffFunction[Double], init: Double = 1.0): Double = {
-    minimizeWithBound(f, init = 1.0, bound = Double.PositiveInfinity)
+    minimizeWithBound(f, init, bound = Double.PositiveInfinity)
   }
 
   /**


### PR DESCRIPTION
Fix the bug that in `StrongWolfeLineSearch.minimize`, it ignore the passed in parameter `init`, it always use 1.0 as init value.

This bug was introduced in #633 and thanks @nerh for finding it.

cc @jkbradley Maybe we need merge this fix into spark ASAP.