### PR TITLE
Add overflow check in SVD

### DIFF
--- a/math/src/main/scala/breeze/linalg/functions/svd.scala
+++ b/math/src/main/scala/breeze/linalg/functions/svd.scala
@@ -84,13 +84,19 @@ object svd extends UFunc {
       case ReducedSVD => DenseMatrix.zeros[Double](m min n,n)
     }
     val iwork = new Array[Int](8 * (m min n) )
-    val workSize = ( 3
+    val workSize = ( 3L
       * scala.math.min(m, n)
       * scala.math.min(m, n)
-      + scala.math.max(scala.math.max(m, n), 4 * scala.math.min(m, n)
-      * scala.math.min(m, n) + 4 * scala.math.min(m, n))
+      + scala.math.max(scala.math.max(m, n), 4L * scala.math.min(m, n)
+      * scala.math.min(m, n) + 4L * scala.math.min(m, n))
       )
-    val work = new Array[Double](workSize)
+    if (workSize >= Int.MaxValue) {
+      throw new RuntimeException(
+        "The param k and numFeatures is too large for SVD computation. " +
+        "Try reducing the parameter k for PCA, or reduce the input feature " +
+        "vector dimension to make this tractable.")
+    }
+    val work = new Array[Double](workSize.toInt)
     val info = new intW(0)
     val cm = copy(mat)
 


### PR DESCRIPTION
The `workSize` in SVD is possible overflow to be negative value (when `m` and `n` is large), it will cause the algo throw `NegativeArraySizeException`. This exception will confuse user.

Add a check for it and if `m` and `n` is too large, throw a user-friendly exception message.

We have done this in spark(https://github.com/apache/spark/pull/19078) but it is better to fix it in breeze.
