### PR TITLE
Changed 'Field' instances not to use 'Rich*.abs'

### DIFF
--- a/math/src/main/scala/breeze/math/Field.scala
+++ b/math/src/main/scala/breeze/math/Field.scala
@@ -44,10 +44,10 @@ object Field {
     def *(a : Int, b : Int) = a * b
     def /(a : Int, b : Int) = a / b
     def %(a: Int, b: Int) = a % b
-    def pow(a: Int, b: Int) = Math.pow(a,b).toInt
+    def pow(a: Int, b: Int) = math.pow(a,b).toInt
 
     implicit val normImpl: norm.Impl[Int, Double] = new norm.Impl[Int,Double] {
-      def apply(v: Int) = v.abs.toDouble
+      def apply(v: Int) = math.abs(v).toDouble
     }
   }
 
@@ -63,10 +63,10 @@ object Field {
     def *(a : Short, b : Short) = (a * b).asInstanceOf[Short]
     def /(a : Short, b : Short) = (a / b).asInstanceOf[Short]
     def %(a: Short, b: Short) = (a % b).asInstanceOf[Short]
-    def pow(a: Short, b: Short) = Math.pow(a,b).toShort
+    def pow(a: Short, b: Short) = math.pow(a,b).toShort
 
     implicit val normImpl: norm.Impl[Short, Double] = new norm.Impl[Short,Double] {
-      def apply(v: Short) = v.abs.toDouble
+      def apply(v: Short) = math.abs(v).toDouble
     }
   }
 
@@ -82,10 +82,10 @@ object Field {
     def *(a : Long, b : Long) = a * b
     def /(a : Long, b : Long) = a / b
     def %(a: Long, b: Long) = a % b.toLong
-    def pow(a: Long, b: Long) = Math.pow(a,b).toLong
+    def pow(a: Long, b: Long) = math.pow(a,b).toLong
 
     implicit val normImpl: norm.Impl[Long, Double] = new norm.Impl[Long,Double] {
-      def apply(v: Long) = v.abs.toDouble
+      def apply(v: Long) = math.abs(v).toDouble
     }
   }
 
@@ -143,10 +143,11 @@ object Field {
     def %(a: Float, b: Float) = a % b
     def pow(a: Float, b: Float) = numerics.pow(a,b)
 
-    override def close(a: Float, b: Float, tolerance: Double) = (a-b).abs <= math.max(a.abs, b.abs) * tolerance
+    override def close(a: Float, b: Float, tolerance: Double) = 
+      math.abs(a-b) <= math.max(a.abs, b.abs) * tolerance
 
     implicit val normImpl: norm.Impl[Float, Double] = new norm.Impl[Float,Double] {
-      def apply(v: Float) = v.abs.toDouble
+      def apply(v: Float) = math.abs(v).toDouble
     }
   }
 
@@ -161,12 +162,13 @@ object Field {
     def *(a: Double, b: Double) = a * b
     def /(a: Double, b: Double) = a / b
     def %(a: Double, b: Double): Double = a % b
-    def pow(a: Double, b: Double): Double = Math.pow(a, b)
+    def pow(a: Double, b: Double): Double = math.pow(a, b)
 
-    override def close(a: Double, b: Double, tolerance: Double) = (a - b).abs <= math.max(a.abs, b.abs) * tolerance
+    override def close(a: Double, b: Double, tolerance: Double) = 
+      math.abs(a - b) <= math.max(a.abs, b.abs) * tolerance
 
     implicit val normImpl: norm.Impl[Double, Double] = new norm.Impl[Double, Double] {
-      def apply(v: Double) = v.abs
+      def apply(v: Double) = math.abs(v)
     }
   }
 }


### PR DESCRIPTION
This is to workaround boxing on Scala 2.10, see SI-7511 and scala/scala#2676.