### PR TITLE
Change FirstOrderMinimizer to return convergence reason

### DIFF
--- a/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
+++ b/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
@@ -90,6 +90,7 @@ abstract class FirstOrderMinimizer[T, DF<:StochasticDiffFunction[T]](val converg
       convergenceCheck.apply(s, s.convergenceInfo) match {
         case Some(converged) =>
           logger.info(s"Converged because ${converged.reason}")
+          s.convergenceReason = Some(converged)
           true
         case None =>
           false
@@ -127,6 +128,7 @@ object FirstOrderMinimizer {
    * @param initialAdjVal f(x_0) + r(x_0), used for checking convergence
    * @param history any information needed by the optimizer to do updates.
    * @param searchFailed did the line search fail?
+   * @param convergenceReason the convergence reason
    */
   case class State[+T, +ConvergenceInfo, +History](x: T,
                                                    value: Double, grad: T,
@@ -135,7 +137,8 @@ object FirstOrderMinimizer {
                                                    initialAdjVal: Double,
                                                    history: History,
                                                    convergenceInfo: ConvergenceInfo,
-                                                   searchFailed: Boolean = false) {
+                                                   searchFailed: Boolean = false,
+                                                   var convergenceReason: Option[ConvergenceReason] = None) {
   }
 
   trait ConvergenceCheck[T] {

--- a/math/src/test/scala/breeze/optimize/LBFGSTest.scala
+++ b/math/src/test/scala/breeze/optimize/LBFGSTest.scala
@@ -161,7 +161,25 @@ class LBFGSTest extends OptimizeTestBase {
     check(Prop.forAll(optimizeThis _))
   }
 
+  test("return convergence reason") {
+    val lbfgs = new LBFGS[DenseVector[Double]](100,4)
 
+    def optimizeThis(init: DenseVector[Double]) = {
+      val f = new DiffFunction[DenseVector[Double]] {
+        def calculate(x: DenseVector[Double]) = {
+          (norm((x - 3.0) ^:^ 2.0, 1), (x *:* 2.0) - 6.0)
+        }
+      }
+
+      val reason = lbfgs.minimizeAndReturnState(f,init).convergenceReason
+      reason.map(r => r.isInstanceOf[MaxIterations] ||
+        r.isInstanceOf[FirstOrderMinimizer.FunctionValuesConverged.type] ||
+        r.isInstanceOf[FirstOrderMinimizer.GradientConverged.type] ||
+        r.isInstanceOf[LineSearchFailed]).getOrElse(false)
+    }
+
+    check(Prop.forAll(optimizeThis _))
+  }
 
 }
 


### PR DESCRIPTION
I want to implement early-stopping using my own convergenceCheck implementation. If the loss of validation data increase, the value of the previous iteration is more appropriate.
So I changed FirstOrderMinimizer to return convergence reason.