### PR TITLE
One allocation less in 'LBFGS.takeStep' and 'LineSearch'

### DIFF
--- a/math/src/main/scala/breeze/optimize/LBFGS.scala
+++ b/math/src/main/scala/breeze/optimize/LBFGS.scala
@@ -19,8 +19,7 @@ package breeze.optimize
 import breeze.linalg._
 import breeze.linalg.operators.OpMulMatrix
 import breeze.math.MutableInnerProductModule
-import breeze.optimize.FirstOrderMinimizer.{ConvergenceCheck, ConvergenceReason}
-import breeze.optimize.linear.PowerMethod
+import breeze.optimize.FirstOrderMinimizer.ConvergenceCheck
 import breeze.util.SerializableLogging
 
 /**
@@ -47,7 +46,12 @@ class LBFGS[T](convergenceCheck: ConvergenceCheck[T], m: Int)(implicit space: Mu
 
   override protected def adjustFunction(f: DiffFunction[T]): DiffFunction[T] = f.cached
 
-  protected def takeStep(state: State, dir: T, stepSize: Double) = state.x + dir * stepSize
+  protected def takeStep(state: State, dir: T, stepSize: Double): T = {
+    val newX = dir * stepSize
+    newX :+= state.x
+    newX
+  }
+
   protected def initialHistory(f: DiffFunction[T], x: T): History = new LBFGS.ApproximateInverseHessian(m)
   protected def chooseDescentDirection(state: State, fn: DiffFunction[T]):T = {
     state.history * state.grad

--- a/math/src/main/scala/breeze/optimize/LineSearch.scala
+++ b/math/src/main/scala/breeze/optimize/LineSearch.scala
@@ -1,6 +1,6 @@
 package breeze.optimize
 
-import breeze.math.InnerProductModule
+import breeze.math.MutableInnerProductModule
 import breeze.util.Implicits._
 
 trait MinimizingLineSearch {
@@ -27,18 +27,28 @@ trait ApproximateLineSearch extends MinimizingLineSearch {
 }
 
 object LineSearch {
-  def functionFromSearchDirection[T, I](f: DiffFunction[T], x: T, direction: T)(implicit prod: InnerProductModule[T, Double]):DiffFunction[Double] = new DiffFunction[Double] {
+  def functionFromSearchDirection[T, I](f: DiffFunction[T], x: T, direction: T)(implicit prod: MutableInnerProductModule[T, Double]): DiffFunction[Double] = new DiffFunction[Double] {
     import prod._
 
     /** calculates the value at a point */
-    override def valueAt(alpha: Double): Double = f.valueAt(x + direction * alpha)
+    override def valueAt(alpha: Double): Double = {
+      val newX = direction * alpha
+      newX :+= x
+      f.valueAt(newX)
+    }
 
     /** calculates the gradient at a point */
-    override def gradientAt(alpha: Double): Double = f.gradientAt(x + direction * alpha) dot direction
+    override def gradientAt(alpha: Double): Double = {
+      val newX = direction * alpha
+      newX :+= x
+      f.gradientAt(newX) dot direction
+    }
 
     /** Calculates both the value and the gradient at a point */
     def calculate(alpha: Double): (Double, Double) = {
-      val (ff, grad) = f.calculate(x + direction * alpha)
+      val newX = direction * alpha
+      newX :+= x
+      val (ff, grad) = f.calculate(newX)
       ff -> (grad dot direction)
     }
   }


### PR DESCRIPTION
When T is a large vector, every allocation counts, and prior to this
commit 'x + dir * alpha' did two allocations instead of one.