### PR TITLE
Added indirectSort

### DIFF
--- a/math/src/main/scala/breeze/linalg/CSCMatrix.scala
+++ b/math/src/main/scala/breeze/linalg/CSCMatrix.scala
@@ -544,11 +544,6 @@ object CSCMatrix extends MatrixConstructors[CSCMatrix]
         out.compact()
       out
     }
-
-    // returns indices of a lexicographic sort of the indices (columns major, rows minor)
-    private def sortedIndices(indices: Array[Long]) = {
-      Sorting.indexSort(indices, 0, indices.length)
-    }
   }
 
   object Builder {

--- a/math/src/main/scala/breeze/linalg/CSCMatrix.scala
+++ b/math/src/main/scala/breeze/linalg/CSCMatrix.scala
@@ -549,7 +549,7 @@ object CSCMatrix extends MatrixConstructors[CSCMatrix]
 
     // returns indices of a lexicographic sort of the indices (columns major, rows minor)
     private def sortedIndices(indices: Array[Long]) = {
-      Sorting.indexSort(indices)
+      Sorting.indexSort(indices, 0, indices.length)
     }
   }
 

--- a/math/src/main/scala/breeze/linalg/VectorBuilder.scala
+++ b/math/src/main/scala/breeze/linalg/VectorBuilder.scala
@@ -14,15 +14,15 @@ package breeze.linalg
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-import scala.reflect.ClassTag
-import scala.{specialized => spec}
-
-import breeze.linalg.operators._
-import breeze.linalg.support._
-import breeze.math.{Ring, Semiring}
+import operators._
+import scala.{specialized=>spec}
+import support._
+import breeze.util.{Sorting, ArrayUtil}
+import breeze.math.{Field, MutableVectorSpace, Semiring, Ring}
 import breeze.storage.Zero
-import breeze.util.{ArrayUtil, Sorting}
-
+import scala.reflect.ClassTag
+import breeze.macros.expand
+import breeze.generic.UFunc.{UImpl2, InPlaceImpl2}
 
 /**
  * A VectorBuilder is basically an unsorted Sparse Vector. Two parallel

--- a/math/src/main/scala/breeze/linalg/VectorBuilder.scala
+++ b/math/src/main/scala/breeze/linalg/VectorBuilder.scala
@@ -184,61 +184,51 @@ class VectorBuilder[@spec(Double, Int, Float, Long) E](private var _index: Array
     hv
   }
 
-  def toSparseVector:SparseVector[E] = toSparseVector(alreadySorted=false)
+  def toSparseVector: SparseVector[E] = toSparseVector()
 
   def toSparseVector(alreadySorted: Boolean = false, keysAlreadyUnique: Boolean = false): SparseVector[E] = {
     requirePositiveLength()
     val index = this.index
     val values = this.data
-    if(alreadySorted && keysAlreadyUnique) {
+    if (alreadySorted && keysAlreadyUnique) {
       return new SparseVector(index, values, used, length)
     }
 
-    val outIndex = new Array[Int](index.length)
-    val outValues = ArrayUtil.newArrayLike(values, values.length)
+    val outIndex = ArrayUtil.copyOf(index, used)
+    val outValues = ArrayUtil.copyOf(values, used)
+    if (!alreadySorted) {
+      Sorting.indirectSort(outIndex, outValues, 0, used)
+    }
 
-    val ord = if(!alreadySorted) sortedIndices(index) else ArrayUtil.range(0, used)
-    if(ord.length > 0) {
-      outIndex(0) = index(ord(0))
-      outValues(0) = values(ord(0))
-      if(index(ord.last) >= length)
-        throw new RuntimeException("Index " + index(ord.last) + " exceeds dimension " + length)
-      else if (outIndex(0) < 0)
-        throw new RuntimeException("Index " + outIndex(0) + " is less than 0!")
+    if (outIndex.length > 0) {
+      if (outIndex(used - 1) >= length) {
+        throw new IndexOutOfBoundsException("Index " + index(used - 1) + " exceeds dimension " + length)
+      } else if (outIndex(0) < 0) {
+        throw new IndexOutOfBoundsException("Index " + outIndex(0) + " is less than 0")
+      }
     }
     var i   = 1
     var out = 0
-    if(keysAlreadyUnique) {
-      while(i < ord.length) {
-        out += 1
-        outIndex(out) = index(ord(i))
-        outValues(out) = values(ord(i))
-        i += 1
-      }
-    } else {
-      while(i < ord.length) {
-        if(outIndex(out) == index(ord(i))) {
-          outValues(out) = ring.+(outValues(out), values(ord(i)))
+    if (!keysAlreadyUnique) {
+      while (i < used) {
+        if (outIndex(out) == outIndex(i)) {
+          outValues(out) = ring.+(outValues(out), outValues(i))
         } else {
           out += 1
-          outIndex(out) = index(ord(i))
-          outValues(out) = values(ord(i))
+          outIndex(out) = outIndex(i)
+          outValues(out) = outValues(i)
         }
         i += 1
       }
+    } else {
+      out = used
     }
 
-    if(ord.length > 0)
+    if (outIndex.length > 0)
       out += 1
 
-    require(ord.length == 0 || length > outIndex.last, "Index out of bounds in constructing sparse vector.")
     new SparseVector(outIndex, outValues, out, length)
   }
-
-  private def sortedIndices(indices: Array[Int]) = {
-    Sorting.indexSort(indices, 0, used)
-  }
-
 
   def compact() {
     val ah = toSparseVector

--- a/math/src/main/scala/breeze/linalg/VectorBuilder.scala
+++ b/math/src/main/scala/breeze/linalg/VectorBuilder.scala
@@ -14,15 +14,14 @@ package breeze.linalg
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-import operators._
-import scala.{specialized=>spec}
-import support._
-import breeze.util.{Sorting, ArrayUtil}
-import breeze.math.{Field, MutableVectorSpace, Semiring, Ring}
-import breeze.storage.Zero
 import scala.reflect.ClassTag
-import breeze.macros.expand
-import breeze.generic.UFunc.{UImpl2, InPlaceImpl2}
+import scala.{specialized => spec}
+
+import breeze.linalg.operators._
+import breeze.linalg.support._
+import breeze.math.{Ring, Semiring}
+import breeze.storage.Zero
+import breeze.util.{ArrayUtil, Sorting}
 
 
 /**

--- a/math/src/main/scala/breeze/linalg/functions/argsort.scala
+++ b/math/src/main/scala/breeze/linalg/functions/argsort.scala
@@ -15,12 +15,10 @@ object argsort extends UFunc with LowPriorityArgSort {
   implicit def argsortDenseVector[@expand.args(Int, Double, Float, Long) T]: Impl[DenseVector[T], IndexedSeq[Int]] = {
     new Impl[DenseVector[T], IndexedSeq[Int]] {
       override def apply(v: DenseVector[T]): IndexedSeq[Int] = {
-        if (v.stride == 1) {
-          Sorting.indexSort(v.data, v.offset, v.length)
-        } else {
-          val data = v.toArray
-          Sorting.indexSort(data, 0, data.length)
-        }
+        val data = v.toArray
+        val index = ArrayUtil.range(0, data.length)
+        Sorting.indirectSort(data, index, 0, data.length)
+        index
       }
     }
   }

--- a/math/src/main/scala/breeze/linalg/functions/argsort.scala
+++ b/math/src/main/scala/breeze/linalg/functions/argsort.scala
@@ -19,7 +19,7 @@ object argsort extends UFunc with LowPriorityArgSort {
           Sorting.indexSort(v.data, v.offset, v.length)
         } else {
           val data = v.toArray
-          Sorting.indexSort(data)
+          Sorting.indexSort(data, 0, data.length)
         }
       }
     }

--- a/math/src/main/scala/breeze/util/Sorting.scala
+++ b/math/src/main/scala/breeze/util/Sorting.scala
@@ -1,5 +1,7 @@
 package breeze.util
 
+import scala.{specialized => spec}
+
 import breeze.macros.expand
 
 /**
@@ -40,25 +42,25 @@ object Sorting {
     idx
   }
 
-  def indirectSort[@specialized(Int, Long, Float, Double) E](
+  def indirectSort[@spec(Int, Long, Float, Double) E](
     keys: Array[Int],
     elems: Array[E],
     off: Int,
     length: Int): Unit = indirectSort_Int(keys, elems, off, length)
 
-  def indirectSort[@specialized(Int, Long, Float, Double) E](
+  def indirectSort[@spec(Int, Long, Float, Double) E](
     keys: Array[Long],
     elems: Array[E],
     off: Int,
     length: Int): Unit = indirectSort_Long(keys, elems, off, length)
 
-  def indirectSort[@specialized(Int, Long, Float, Double) E](
+  def indirectSort[@spec(Int, Long, Float, Double) E](
     keys: Array[Float],
     elems: Array[E],
     off: Int,
     length: Int): Unit = indirectSort_Float(keys, elems, off, length)
 
-  def indirectSort[@specialized(Int, Long, Float, Double) E](
+  def indirectSort[@spec(Int, Long, Float, Double) E](
     keys: Array[Double],
     elems: Array[E],
     off: Int,
@@ -75,7 +77,7 @@ object Sorting {
    * The implementation is not stable.
    */
   @expand
-  def indirectSort[@expand.args(Int, Long, Float, Double) K, @specialized(Int, Long, Float, Double) E](
+  def indirectSort[@expand.args(Int, Long, Float, Double) K, @spec(Int, Long, Float, Double) E](
     keys: Array[K],
     elems: Array[E],
     off: Int,

--- a/math/src/main/scala/breeze/util/Sorting.scala
+++ b/math/src/main/scala/breeze/util/Sorting.scala
@@ -17,31 +17,7 @@ object Sorting {
   //** /____/\___/_/ |_/____/_/ | |                                         **
   //**                          |/                                          **
   //\*                                                                      */
-
-  def indexSort(elems: Array[Int], off: Int, length: Int): Array[Int] = {
-    val idx = ArrayUtil.range(0, length)
-    indirectSort(elems.clone(), idx, off, length)
-    idx
-  }
-
-  def indexSort(elems: Array[Long], off: Int, length: Int): Array[Int] = {
-    val idx = ArrayUtil.range(0, length)
-    indirectSort(elems.clone(), idx, off, length)
-    idx
-  }
-
-  def indexSort(elems: Array[Float], off: Int, length: Int): Array[Int] = {
-    val idx = ArrayUtil.range(0, length)
-    indirectSort(elems.clone(), idx, off, length)
-    idx
-  }
-
-  def indexSort(elems: Array[Double], off: Int, length: Int): Array[Int] = {
-    val idx = ArrayUtil.range(0, length)
-    indirectSort(elems.clone(), idx, 0, elems.length)
-    idx
-  }
-
+  
   def indirectSort[@spec(Int, Long, Float, Double) E](
     keys: Array[Int],
     elems: Array[E],

--- a/math/src/main/scala/breeze/util/Sorting.scala
+++ b/math/src/main/scala/breeze/util/Sorting.scala
@@ -17,44 +17,42 @@ object Sorting {
   //\*                                                                      */
 
   def indexSort(elems: Array[Int], off: Int, length: Int): Array[Int] = {
-    indexSort_Int(elems, off, length)
+    val idx = ArrayUtil.range(0, length)
+    indirectSort_Int_Int(elems.clone(), idx, off, length)
+    idx
   }
 
   def indexSort(elems: Array[Long], off: Int, length: Int): Array[Int] = {
-    indexSort_Long(elems, off, length)
+    val idx = ArrayUtil.range(0, length)
+    indirectSort_Long_Int(elems.clone(), idx, off, length)
+    idx
   }
 
   def indexSort(elems: Array[Float], off: Int, length: Int): Array[Int] = {
-    indexSort_Float(elems, off, length)
+    val idx = ArrayUtil.range(0, length)
+    indirectSort_Float_Int(elems.clone(), idx, off, length)
+    idx
   }
 
   def indexSort(elems: Array[Double], off: Int, length: Int): Array[Int] = {
-    indexSort_Double(elems, 0, elems.length)
-  }
-
-  def indexSort(elems: Array[Int]): Array[Int] = {
-    indexSort(elems, 0, elems.length)
-  }
-
-  def indexSort(elems: Array[Long]): Array[Int] = {
-    indexSort(elems, 0, elems.length)
-  }
-
-  def indexSort(elems: Array[Float]): Array[Int] = {
-    indexSort(elems, 0, elems.length)
-  }
-
-  def indexSort(elems: Array[Double]): Array[Int] = {
-    indexSort(elems, 0, elems.length)
+    val idx = ArrayUtil.range(0, length)
+    indirectSort_Double_Int(elems.clone(), idx, 0, elems.length)
+    idx
   }
 
   @expand
-  def indexSort[@expand.args(Int, Long, Float, Double) T](elems: Array[T], elemsOff: Int, elemsLength: Int): Array[Int] = {
-    val idx = ArrayUtil.range(0, elemsLength)
+  def indirectSort[@expand.args(Int, Long, Float, Double) K, @expand.args(Int, Long, Float, Double) E](
+    keys: Array[K],
+    elems: Array[E],
+    off: Int,
+    length: Int): Unit = {
     def swap(a: Int, b: Int) {
-      val t = idx(a)
-      idx(a) = idx(b)
-      idx(b) = t
+      val t0 = keys(a)
+      keys(a) = keys(b)
+      keys(b) = t0
+      val t1 = elems(a)
+      elems(a) = elems(b)
+      elems(b) = t1
     }
     def vecswap(_a: Int, _b: Int, n: Int) {
       var a = _a
@@ -68,19 +66,19 @@ object Sorting {
       }
     }
     def med3(a: Int, b: Int, c: Int) = {
-      if (elems(elemsOff + idx(a)) < elems(elemsOff + idx(b))) {
-        if (elems(elemsOff + idx(b)) < elems(elemsOff + idx(c))) b else if (elems(elemsOff + idx(a)) < elems(elemsOff + idx(c))) c else a
+      if (keys(a) < keys(b)) {
+        if (keys(b) < keys(c)) b else if (keys(a) < keys(c)) c else a
       } else {
-        if (elems(elemsOff + idx(b)) > elems(elemsOff + idx(c))) b else if (elems(elemsOff + idx(a)) > elems(elemsOff + idx(c))) c else a
+        if (keys(b) > keys(c)) b else if (keys(a) > keys(c)) c else a
       }
     }
-    def sort2(off: Int, len: Int) {
+    def sort2(off: Int, length: Int) {
       // Insertion sort on smallest arrays
-      if (len < 7) {
+      if (length < 7) {
         var i = off
-        while (i < len + off) {
+        while (i < length + off) {
           var j = i
-          while (j>off && elems(elemsOff + idx(j-1)) > elems(elemsOff + idx(j))) {
+          while (j>off && keys(j-1) > keys(j)) {
             swap(j, j-1)
             j -= 1
           }
@@ -88,36 +86,36 @@ object Sorting {
         }
       } else {
         // Choose a partition element, v
-        var m = off + (len >> 1)        // Small arrays, middle element
-        if (len > 7) {
+        var m = off + (length >> 1)        // Small arrays, middle element
+        if (length > 7) {
           var l = off
-          var n = off + len - 1
-          if (len > 40) {        // Big arrays, pseudomedian of 9
-            val s = len / 8
+          var n = off + length - 1
+          if (length > 40) {        // Big arrays, pseudomedian of 9
+            val s = length / 8
             l = med3(l, l+s, l+2*s)
             m = med3(m-s, m, m+s)
             n = med3(n-2*s, n-s, n)
           }
           m = med3(l, m, n) // Mid-size, med of 3
         }
-        val v = elems(elemsOff + idx(m))
+        val v = keys(m)
 
         // Establish Invariant: v* (<v)* (>v)* v*
         var a = off
         var b = a
-        var c = off + len - 1
+        var c = off + length - 1
         var d = c
         var done = false
         while (!done) {
-          while (b <= c && elems(elemsOff + idx(b)) <= v) {
-            if (elems(elemsOff + idx(b)) == v) {
+          while (b <= c && keys(b) <= v) {
+            if (keys(b) == v) {
               swap(a, b)
               a += 1
             }
             b += 1
           }
-          while (c >= b && elems(elemsOff + idx(c)) >= v) {
-            if (elems(elemsOff + idx(c)) == v) {
+          while (c >= b && keys(c) >= v) {
+            if (keys(c) == v) {
               swap(c, d)
               d -= 1
             }
@@ -133,7 +131,7 @@ object Sorting {
         }
 
         // Swap partition elements back to middle
-        val n = off + len
+        val n = off + length
         var s = math.min(a-off, b-a)
         vecswap(off, b-s, s)
         s = math.min(d-c, n-d-1)
@@ -148,10 +146,6 @@ object Sorting {
           sort2(n-s, s)
       }
     }
-    sort2(0, idx.length)
-
-    idx
+    sort2(off, length)
   }
-
-
 }

--- a/math/src/main/scala/breeze/util/Sorting.scala
+++ b/math/src/main/scala/breeze/util/Sorting.scala
@@ -18,30 +18,54 @@ object Sorting {
 
   def indexSort(elems: Array[Int], off: Int, length: Int): Array[Int] = {
     val idx = ArrayUtil.range(0, length)
-    indirectSort_Int_Int(elems.clone(), idx, off, length)
+    indirectSort(elems.clone(), idx, off, length)
     idx
   }
 
   def indexSort(elems: Array[Long], off: Int, length: Int): Array[Int] = {
     val idx = ArrayUtil.range(0, length)
-    indirectSort_Long_Int(elems.clone(), idx, off, length)
+    indirectSort(elems.clone(), idx, off, length)
     idx
   }
 
   def indexSort(elems: Array[Float], off: Int, length: Int): Array[Int] = {
     val idx = ArrayUtil.range(0, length)
-    indirectSort_Float_Int(elems.clone(), idx, off, length)
+    indirectSort(elems.clone(), idx, off, length)
     idx
   }
 
   def indexSort(elems: Array[Double], off: Int, length: Int): Array[Int] = {
     val idx = ArrayUtil.range(0, length)
-    indirectSort_Double_Int(elems.clone(), idx, 0, elems.length)
+    indirectSort(elems.clone(), idx, 0, elems.length)
     idx
   }
 
+  def indirectSort[@specialized(Int, Long, Float, Double) E](
+    keys: Array[Int],
+    elems: Array[E],
+    off: Int,
+    length: Int): Unit = indirectSort_Int(keys, elems, off, length)
+
+  def indirectSort[@specialized(Int, Long, Float, Double) E](
+    keys: Array[Long],
+    elems: Array[E],
+    off: Int,
+    length: Int): Unit = indirectSort_Long(keys, elems, off, length)
+
+  def indirectSort[@specialized(Int, Long, Float, Double) E](
+    keys: Array[Float],
+    elems: Array[E],
+    off: Int,
+    length: Int): Unit = indirectSort_Float(keys, elems, off, length)
+
+  def indirectSort[@specialized(Int, Long, Float, Double) E](
+    keys: Array[Double],
+    elems: Array[E],
+    off: Int,
+    length: Int): Unit = indirectSort_Double(keys, elems, off, length)
+
   @expand
-  def indirectSort[@expand.args(Int, Long, Float, Double) K, @expand.args(Int, Long, Float, Double) E](
+  def indirectSort[@expand.args(Int, Long, Float, Double) K, @specialized(Int, Long, Float, Double) E](
     keys: Array[K],
     elems: Array[E],
     off: Int,

--- a/math/src/main/scala/breeze/util/Sorting.scala
+++ b/math/src/main/scala/breeze/util/Sorting.scala
@@ -64,12 +64,23 @@ object Sorting {
     off: Int,
     length: Int): Unit = indirectSort_Double(keys, elems, off, length)
 
+  /**
+   * Jointly sorts `keys`/`elems` in-place based on the items in the
+   * `keys` array.
+   *
+   * If `off` is non-zero or `length` is less than the length of the arrays,
+   * then only the subarrays specified by these arguments are modified. All
+   * other items remain unchanged.
+   *
+   * The implementation is not stable.
+   */
   @expand
   def indirectSort[@expand.args(Int, Long, Float, Double) K, @specialized(Int, Long, Float, Double) E](
     keys: Array[K],
     elems: Array[E],
     off: Int,
     length: Int): Unit = {
+    require(keys.length == elems.length, "arrays must have the same length")
     def swap(a: Int, b: Int) {
       val t0 = keys(a)
       keys(a) = keys(b)

--- a/math/src/test/scala/breeze/linalg/CSCMatrixTest.scala
+++ b/math/src/test/scala/breeze/linalg/CSCMatrixTest.scala
@@ -147,6 +147,14 @@ class CSCMatrixTest extends FunSuite with Checkers with MatrixTestUtils {
     builder.add(1, 1, 2.0)
   }
 
+  test("Builder idempotency") {
+    val builder = new CSCMatrix.Builder[Double](3, 3)
+    builder.add(1, 1, 2.0)
+    val r1 = builder.result
+    val r2 = builder.result
+    assert(r1 === r2)
+  }
+
   test("Builder, full") {
     val builder = new CSCMatrix.Builder[Double](2, 3)
     builder.add(0, 1, 2.0)

--- a/math/src/test/scala/breeze/linalg/VectorBuilderTest.scala
+++ b/math/src/test/scala/breeze/linalg/VectorBuilderTest.scala
@@ -20,7 +20,15 @@ class VectorBuilderTest extends FunSuite with Checkers {
     assert(vb.data.length === 4)
   }
 
-  test("Basic VectorBuilder result tests") {
+  test("toSparseVector on empty") {
+    assert(VectorBuilder[Double]().toSparseVector === SparseVector[Double]())
+  }
+
+  test("toSparseVector on singleton") {
+    assert(VectorBuilder[Double](1.0).toSparseVector === SparseVector[Double](1.0))
+  }
+
+  test("toSparseVector/toHashVector on multiple") {
     val vb = VectorBuilder[Double](0.0, 1.0, 3.0)
 
     assert(vb.toSparseVector === SparseVector[Double](0.0, 1.0, 3.0))
@@ -47,13 +55,12 @@ class VectorBuilderTest extends FunSuite with Checkers {
     }
   }
 
-  test("Dot product is consistent") {
+  test("dot is consistent") {
     check(Prop.forAll{ (pair: (VectorBuilder[Double], VectorBuilder[Double])) =>
       val (vb1,vb2) = pair
       val (hv1, hv2) = (vb1.toHashVector, vb2.toHashVector)
        closeTo(vb1 dot hv2, hv1 dot vb2) && closeTo(vb1 dot hv2, hv1 dot hv2)
     })
-
   }
 
   test("+ for VB's and V's is consistent") {

--- a/math/src/test/scala/breeze/linalg/VectorBuilderTest.scala
+++ b/math/src/test/scala/breeze/linalg/VectorBuilderTest.scala
@@ -23,8 +23,8 @@ class VectorBuilderTest extends FunSuite with Checkers {
   test("Basic VectorBuilder result tests") {
     val vb = VectorBuilder[Double](0.0, 1.0, 3.0)
 
-    assert(vb.toSparseVector === SparseVector[Double](0.0, 1.0, 3.0))
-    assert(vb.toHashVector === HashVector[Double](0.0, 1.0, 3.0))
+//    assert(vb.toSparseVector === SparseVector[Double](0.0, 1.0, 3.0))
+//    assert(vb.toHashVector === HashVector[Double](0.0, 1.0, 3.0))
     vb.add(0, 4.0)
     assert(vb.toSparseVector === SparseVector[Double](4.0, 1.0, 3.0))
     assert(vb.toHashVector === HashVector[Double](4.0, 1.0, 3.0))

--- a/math/src/test/scala/breeze/linalg/VectorBuilderTest.scala
+++ b/math/src/test/scala/breeze/linalg/VectorBuilderTest.scala
@@ -23,8 +23,8 @@ class VectorBuilderTest extends FunSuite with Checkers {
   test("Basic VectorBuilder result tests") {
     val vb = VectorBuilder[Double](0.0, 1.0, 3.0)
 
-//    assert(vb.toSparseVector === SparseVector[Double](0.0, 1.0, 3.0))
-//    assert(vb.toHashVector === HashVector[Double](0.0, 1.0, 3.0))
+    assert(vb.toSparseVector === SparseVector[Double](0.0, 1.0, 3.0))
+    assert(vb.toHashVector === HashVector[Double](0.0, 1.0, 3.0))
     vb.add(0, 4.0)
     assert(vb.toSparseVector === SparseVector[Double](4.0, 1.0, 3.0))
     assert(vb.toHashVector === HashVector[Double](4.0, 1.0, 3.0))

--- a/math/src/test/scala/breeze/util/SortingTest.scala
+++ b/math/src/test/scala/breeze/util/SortingTest.scala
@@ -6,7 +6,7 @@ class SortingTest extends FunSuite {
   test("indirectSort") {
     val keys = Array(5, 4, 3, 2, 1)
     val elems = Array(1.0, 2.0, 3.0, 4.0, 5.0)
-    Sorting.indirectSort_Int_Double(keys, elems, 0, elems.length)
+    Sorting.indirectSort(keys, elems, 0, elems.length)
     assert(keys === Array(1, 2, 3, 4, 5))
     assert(elems === Array(5.0, 4.0, 3.0, 2.0, 1.0))
   }
@@ -15,7 +15,7 @@ class SortingTest extends FunSuite {
     val keys = Array(5, 4, 3, 2, 1)
     val elems = Array(1.0, 2.0, 3.0, 4.0, 5.0)
     val off = 2
-    Sorting.indirectSort_Int_Double(keys, elems, off, elems.length - off)
+    Sorting.indirectSort(keys, elems, off, elems.length - off)
     assert(keys.take(off) === Array(5, 4))
     assert(keys.drop(off) === Array(1, 2, 3))
     assert(elems === Array(1.0, 2.0, 5.0, 4.0, 3.0))
@@ -26,7 +26,7 @@ class SortingTest extends FunSuite {
     val elems = Array(1.0, 2.0, 3.0, 4.0, 5.0)
     val off = 2
     val len = 2
-    Sorting.indirectSort_Int_Double(keys, elems, off, len)
+    Sorting.indirectSort(keys, elems, off, len)
     assert(keys.take(off) === Array(5, 4))
     assert(keys.slice(off, off + len) === Array(2, 3))
     assert(keys.last === 1)

--- a/math/src/test/scala/breeze/util/SortingTest.scala
+++ b/math/src/test/scala/breeze/util/SortingTest.scala
@@ -1,0 +1,35 @@
+package breeze.util
+
+import org.scalatest.FunSuite
+
+class SortingTest extends FunSuite {
+  test("indirectSort") {
+    val keys = Array(5, 4, 3, 2, 1)
+    val elems = Array(1.0, 2.0, 3.0, 4.0, 5.0)
+    Sorting.indirectSort_Int_Double(keys, elems, 0, elems.length)
+    assert(keys === Array(1, 2, 3, 4, 5))
+    assert(elems === Array(5.0, 4.0, 3.0, 2.0, 1.0))
+  }
+
+  test("indirectSort with offset") {
+    val keys = Array(5, 4, 3, 2, 1)
+    val elems = Array(1.0, 2.0, 3.0, 4.0, 5.0)
+    val off = 2
+    Sorting.indirectSort_Int_Double(keys, elems, off, elems.length - off)
+    assert(keys.take(off) === Array(5, 4))
+    assert(keys.drop(off) === Array(1, 2, 3))
+    assert(elems === Array(1.0, 2.0, 5.0, 4.0, 3.0))
+  }
+
+  test("indirectSort with offset and length") {
+    val keys = Array(5, 4, 3, 2, 1)
+    val elems = Array(1.0, 2.0, 3.0, 4.0, 5.0)
+    val off = 2
+    val len = 2
+    Sorting.indirectSort_Int_Double(keys, elems, off, len)
+    assert(keys.take(off) === Array(5, 4))
+    assert(keys.slice(off, off + len) === Array(2, 3))
+    assert(keys.last === 1)
+    assert(elems === Array(1.0, 2.0, 4.0, 3.0, 5.0))
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.0.3

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.3
+sbt.version=1.0.2


### PR DESCRIPTION
Indirect sorting allows to sort one or more arrays based on the values
in the key array. The current implementation generalizes indexSort with
one (unfortunate) drawback: each call to indexSort now requires two
allocations.