### PR TITLE
Don't insert default value in OpenHashArray

### DIFF
--- a/math/src/main/scala/breeze/collection/mutable/OpenAddressHashArray.scala
+++ b/math/src/main/scala/breeze/collection/mutable/OpenAddressHashArray.scala
@@ -94,15 +94,8 @@ final class OpenAddressHashArray[@specialized(Int, Float, Long, Double) V] priva
   final def update(i: Int, v: V) {
     if (i < 0 || i >= size) throw new IndexOutOfBoundsException(i + " is out of bounds for size " + size)
     val pos = locate(i)
-
-    if (_index(pos) == i) {
-      _data(pos) = v
-    }
-    else if (v == defaultValue.value) {
-      return
-    }
-    else {
-      _data(pos) = v
+    _data(pos) = v
+    if (_index(pos) != i && v != defaultValue.value) {
       load += 1
       if (load * 4 > _index.length * 3) {
         rehash()

--- a/math/src/main/scala/breeze/collection/mutable/OpenAddressHashArray.scala
+++ b/math/src/main/scala/breeze/collection/mutable/OpenAddressHashArray.scala
@@ -95,8 +95,14 @@ final class OpenAddressHashArray[@specialized(Int, Float, Long, Double) V] priva
     if (i < 0 || i >= size) throw new IndexOutOfBoundsException(i + " is out of bounds for size " + size)
     val pos = locate(i)
 
-    _data(pos) = v
-    if (_index(pos) != i && v != defaultValue.value) {
+    if (_index(pos) == i) {
+      _data(pos) = v
+    }
+    else if (v == defaultValue.value) {
+      return
+    }
+    else {
+      _data(pos) = v
       load += 1
       if (load * 4 > _index.length * 3) {
         rehash()
@@ -105,6 +111,7 @@ final class OpenAddressHashArray[@specialized(Int, Float, Long, Double) V] priva
         _index(pos) = i
       }
     }
+
   }
 
   def activeKeysIterator = keysIterator

--- a/math/src/main/scala/breeze/collection/mutable/OpenAddressHashArray.scala
+++ b/math/src/main/scala/breeze/collection/mutable/OpenAddressHashArray.scala
@@ -94,8 +94,9 @@ final class OpenAddressHashArray[@specialized(Int, Float, Long, Double) V] priva
   final def update(i: Int, v: V) {
     if (i < 0 || i >= size) throw new IndexOutOfBoundsException(i + " is out of bounds for size " + size)
     val pos = locate(i)
+
     _data(pos) = v
-    if (_index(pos) != i) {
+    if (_index(pos) != i && v != defaultValue.value) {
       load += 1
       if (load * 4 > _index.length * 3) {
         rehash()

--- a/math/src/test/scala/breeze/collection/mutable/OpenAddressHashArrayTest.scala
+++ b/math/src/test/scala/breeze/collection/mutable/OpenAddressHashArrayTest.scala
@@ -78,8 +78,13 @@ class OpenAddressHashArrayTest extends FunSuite with Checkers {
     assert(oah(0) == -1.0)
     assert(oah(1) == -1.0)
     assert(oah.activeSize == 0)
+
     oah(0) = -1.0
     assert(oah(0) == -1.0)
     assert(oah.activeSize == 0)
+
+    oah(1) = 1.0
+    oah(1) = -1.0
+    assert(oah(1) == -1.0)
   }
 }

--- a/math/src/test/scala/breeze/collection/mutable/OpenAddressHashArrayTest.scala
+++ b/math/src/test/scala/breeze/collection/mutable/OpenAddressHashArrayTest.scala
@@ -73,4 +73,13 @@ class OpenAddressHashArrayTest extends FunSuite with Checkers {
     assert(oah(1) == -1.0)
   }
 
+  test("adding default value doesn't do anything") {
+    val oah = new OpenAddressHashArray[Double](10, -1.0, 3)
+    assert(oah(0) == -1.0)
+    assert(oah(1) == -1.0)
+    assert(oah.activeSize == 0)
+    oah(0) = -1.0
+    assert(oah(0) == -1.0)
+    assert(oah.activeSize == 0)
+  }
 }


### PR DESCRIPTION
If we are inserting a new element, and that element is the default, then
we don't do anything and don't increase the load factor.

NB: default value can still be inserted if it is inserted after a non-
default value that was inserted with the same key. We could remove the
entry in that case but that would require more work