### PR TITLE
Fixed some performance issues with HV/SV operations

### DIFF
--- a/math/src/main/scala/breeze/collection/mutable/OpenAddressHashArray.scala
+++ b/math/src/main/scala/breeze/collection/mutable/OpenAddressHashArray.scala
@@ -18,10 +18,10 @@ package breeze.collection.mutable
 
 import java.util
 
-import breeze.storage.{ConfigurableDefault, Storage, Zero}
-
 import scala.reflect.ClassTag
 import scala.util.hashing.MurmurHash3
+
+import breeze.storage.{ConfigurableDefault, Storage, Zero}
 
 /**
  * This is a Sparse Array implementation backed by a linear-probing
@@ -31,9 +31,9 @@ import scala.util.hashing.MurmurHash3
  */
 @SerialVersionUID(1L)
 final class OpenAddressHashArray[@specialized(Int, Float, Long, Double) V] private[mutable] (
-    protected var _index: Array[Int],
-    protected var _data: Array[V],
-    protected var load: Int,
+    private[mutable] var _index: Array[Int],
+    private[mutable] var _data: Array[V],
+    private[mutable] var load: Int,
     val size: Int,
     val default: ConfigurableDefault[V] = ConfigurableDefault.default[V])(
     implicit protected val manElem: ClassTag[V],
@@ -169,6 +169,14 @@ final class OpenAddressHashArray[@specialized(Int, Float, Long, Double) V] priva
       load,
       size,
       default)
+  }
+
+  def copyTo(other: OpenAddressHashArray[V]): Unit = {
+    require(other.length == other.length, "vectors must have the same length")
+    require(defaultValue == other.defaultValue, "vectors must have the same default")
+    other._index = _index.clone()
+    other._data = _data.clone()
+    other.load = load
   }
 
   def clear(): Unit = {

--- a/math/src/main/scala/breeze/linalg/HashVector.scala
+++ b/math/src/main/scala/breeze/linalg/HashVector.scala
@@ -52,7 +52,7 @@ class HashVector[@spec(Double, Int, Float, Long) E](val array: OpenAddressHashAr
   final def index = array.index
   final def isActive(i: Int) = array.isActive(i)
 
-  def clear() = array.clear()
+  def clear(): Unit = array.clear()
 
   override def toString = {
     activeIterator.mkString("HashVector(", ", ", ")")

--- a/math/src/test/scala/breeze/linalg/HashVectorTest.scala
+++ b/math/src/test/scala/breeze/linalg/HashVectorTest.scala
@@ -7,7 +7,6 @@ import breeze.math._
 import breeze.stats.mean
 import breeze.storage.Zero
 import org.scalacheck.{Arbitrary, Gen}
-
 import scala.reflect.ClassTag
 
 /**
@@ -212,23 +211,25 @@ class HashVectorTest extends FunSuite {
   }
 
   test("HV/SV ops") {
-    val a = SparseVector(3)((1, 2), (2, 3))
-    val b = HashVector(3)((1, 1))
+    val size = 3
+    val a = SparseVector(size)(1 -> 2, 2 -> 3)
+    val b = HashVector(size)(1 -> 1)
     assert(b.dot(a) === 2)
-    assert(b + a === HashVector(0, 3, 3))
-    assert(b *:* a === HashVector(0, 2, 0))
+    assert(b + a === HashVector(size)(1 -> 3, 2 -> 3))
+    assert(b *:* a === HashVector(size)(1 -> 2))
     b += a
-    assert(b === HashVector(0, 3, 3))
+    assert(b === HashVector(size)(1 -> 3, 2 -> 3))
   }
 
   test("SV/HV ops") {
-    val a = SparseVector(3)((1, 2), (2, 3))
-    val b = HashVector(3)((1, 1))
+    val size = 3
+    val a = SparseVector(size)(1 -> 2, 2 -> 3)
+    val b = HashVector(size)(1 -> 1)
     assert(a.dot(b) === 2)
-    assert(a + b === SparseVector(0, 3, 3))
-    assert(a *:* b === SparseVector(0, 2, 0))
+    assert(a + b === HashVector(size)(1 -> 3, 2 -> 3))
+    assert(a *:* b === HashVector(size)(1 -> 2))
     a += b
-    assert(a === SparseVector(0, 3, 3))
+    assert(a === HashVector(size)(1 -> 3, 2 -> 3))
   }
 }
 

--- a/math/src/test/scala/breeze/linalg/HashVectorTest.scala
+++ b/math/src/test/scala/breeze/linalg/HashVectorTest.scala
@@ -60,6 +60,13 @@ class HashVectorTest extends FunSuite {
     assertClose(norm(bss, 2), norm(bd, 2))
   }
 
+  test("Set") {
+    val a = HashVector.zeros[Double](1024)
+    val b = HashVector(1024)(42 -> 0.5)
+    a := b
+    assert(a.activeSize == 1)
+  }
+
   test("Norm") {
     val v = HashVector(-0.4326, -1.6656, 0.1253, 0.2877, -1.1465)
     assertClose(norm(v, 1), 3.6577)


### PR DESCRIPTION
Notably,

```scala
a :+= b
```

no longer produces an extra copy, and

```scala
a := b  // both HV
```

no longer densifies a.