### PR TITLE
OpenAddressHashArray - fix compilation failure

### DIFF
--- a/math/src/main/scala/breeze/collection/mutable/OpenAddressHashArray.scala
+++ b/math/src/main/scala/breeze/collection/mutable/OpenAddressHashArray.scala
@@ -95,7 +95,7 @@ final class OpenAddressHashArray[@specialized(Int, Float, Long, Double) V] priva
     if (i < 0 || i >= size) throw new IndexOutOfBoundsException(i + " is out of bounds for size " + size)
     val pos = locate(i)
     _data(pos) = v
-    if (_index(pos) != i && v != defaultValue.value) {
+    if (_index(pos) != i && v != defaultValue) {
       load += 1
       if (load * 4 > _index.length * 3) {
         rehash()


### PR DESCRIPTION
Hello folks. A very small change here.

I noticed that you have had some issues with failing builds for a while and decided to look into it. I found one trivial compilation problem, that was probably introduced in the PR #693 (perhaps because the build was already red before, so it went unnoticed?).

The problem I am trying to fix:
```
[error] /home/travis/build/scalanlp/breeze/math/src/main/scala/breeze/collection/mutable/OpenAddressHashArray.scala:98:47: value value is not a member of type parameter V
[error]     if (_index(pos) != i && v != defaultValue.value) {
[error]                                               ^
```
You can see it e.g. in the last master branch build https://travis-ci.org/scalanlp/breeze/jobs/358239638

Feel free to discard my PR if you have a fix ready somewhere else.

The builds will stay red, as it seems that there are some problem with Scala 2.10 version.
