### PR TITLE
upgrade sbt-api-mappings

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
 //addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.0.2")
 
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.0.0")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.1.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")


### PR DESCRIPTION
motivation: allow building on Java 9+.
context: https://github.com/scala/community-builds/issues/609