### PR TITLE
Fix SparseVector.horzcat activeSize bug

### DIFF
--- a/math/src/main/scala/breeze/linalg/SparseVector.scala
+++ b/math/src/main/scala/breeze/linalg/SparseVector.scala
@@ -222,7 +222,7 @@ object SparseVector
         "vector lengths must be equal, but got: " + vectors.map(_.length).mkString(", "))
     val rows = vectors(0).length
     val cols = vectors.length
-    val data = new Array[V](vectors.map(_.data.length).sum)
+    val data = new Array[V](vectors.map(_.activeSize).sum)
     val rowIndices = new Array[Int](data.length)
     val colPtrs = new Array[Int](vectors.length + 1)
     val used = data.length


### PR DESCRIPTION
```scala
val (idx, dt) = (0 until 5).map(i => (i, i)).unzip
val v = new BSV(dt.toArray, idx.toArray, 20)
println(v) // SparseVector(20)((0,0), (1,1), (2,2), (3,3), (4,4))
println(v.data.toList) // List(0, 1, 2, 3, 4)
println(v.activeSize) // 5
println(SparseVector.horzcat(v).activeSize) // 5
val vv = v * 2
println(vv) // SparseVector(20)((0,0), (1,2), (2,4), (3,6), (4,8))
println(vv.data.toList) // List(0, 2, 4, 6, 8, 0, 0, 0)
println(vv.activeSize) // 5
println(SparseVector.horzcat(vv).activeSize) // 8
```
The problem is `SparseVector.horzcat` use sum of `data.length` to compute the `activeSize` of the result `SparseMatrix`.

The reason why why `val vv = v * 2` makes the internal `data` expanded is the following:

https://github.com/scalanlp/breeze/blob/09241acb5ca491c4b68c9b91d9e27bb7a25cdfc2/math/src/main/scala/breeze/linalg/operators/SparseVectorOps.scala#L804

https://github.com/scalanlp/breeze/blob/09241acb5ca491c4b68c9b91d9e27bb7a25cdfc2/math/src/main/scala/breeze/linalg/VectorBuilder.scala#L107

`reallocate` function doubled the size of `_data` when it is full. Hence, it is not safe to use `data.length` to determine the `activeSize`