### PR TITLE
Fix mpow for m with complex eigenvalues

### DIFF
--- a/math/src/main/scala/breeze/linalg/functions/mpow.scala
+++ b/math/src/main/scala/breeze/linalg/functions/mpow.scala
@@ -14,7 +14,7 @@ object mpow extends UFunc {
     if (exp == 0) {
       DenseMatrix.eye[Double](m.rows)
     } else if (exp < 0) {
-      powM(inv(m), -exp)
+      powBySquaring(inv(m), -exp)
     } else {
       var res_odds = DenseMatrix.eye[Double](m.rows)
       var res = m

--- a/math/src/main/scala/breeze/linalg/functions/mpow.scala
+++ b/math/src/main/scala/breeze/linalg/functions/mpow.scala
@@ -35,7 +35,6 @@ object mpow extends UFunc {
 
   implicit object implDM_Double_Double extends Impl2[DenseMatrix[Double], Double, DenseMatrix[Double]] {
     def apply(m: DenseMatrix[Double], exp: Double): DenseMatrix[Double] = {
-      // Unclear if the answer makes mathematical sense if exp isn't integer. Maybe raise warning?
       requireSquareMatrix(m)
       val Eig(real, imag, evectors) = eig(m)
       if (norm(imag, 1.0) == 0.0) {
@@ -43,7 +42,7 @@ object mpow extends UFunc {
 
         (evectors.t \ (evectors * diag(exped)).t).t
       } else {
-        require(exp % 1 == 0, "If m has complex eigenvalues exp need to be Int")
+        require(exp % 1 == 0, "If m has complex eigenvalues exp need to be integer")
         powBySquaring(m, exp.toInt)
       }
     }

--- a/math/src/main/scala/breeze/linalg/functions/mpow.scala
+++ b/math/src/main/scala/breeze/linalg/functions/mpow.scala
@@ -4,19 +4,48 @@ import breeze.generic.UFunc
 import breeze.linalg.eig.Eig
 
 /**
- * Raises m to the exp'th power via eigenvalue decomposition. Currently requires
- * that m's eigenvalues are real.
+ * Raises m to the exp'th power. Relies on eigenvalue decomposition when m's
+ * eigenvalues are real, if not it relies on exponentiation by squaring.
  */
 object mpow extends UFunc {
 
+  private def powBySquaring(m: DenseMatrix[Double], exp: Int): DenseMatrix[Double] = {
+    // Assuming that m is square because it has already been verified
+    if (exp == 0) {
+      DenseMatrix.eye[Double](m.rows)
+    } else if (exp < 0) {
+      powM(inv(m), -exp)
+    } else {
+      var res_odds = DenseMatrix.eye[Double](m.rows)
+      var res = m
+      var n = exp
+      while( n > 1) {
+        if (n % 2 == 0) {
+          res = res * res
+          n = n / 2
+        } else {
+          res_odds = res * res_odds
+          res = res * res
+          n = (n - 1) / 2
+        }
+      }
+      res * res_odds
+    }
+  }
+
   implicit object implDM_Double_Double extends Impl2[DenseMatrix[Double], Double, DenseMatrix[Double]] {
     def apply(m: DenseMatrix[Double], exp: Double): DenseMatrix[Double] = {
+      // Unclear if the answer makes mathematical sense if exp isn't integer. Maybe raise warning?
       requireSquareMatrix(m)
       val Eig(real, imag, evectors) = eig(m)
-      require(norm(imag, 1.0) == 0.0, "We cannot handle complex eigenvalues yet.")
-      val exped = new DenseVector(real.data.map(scala.math.pow(_, exp)))
+      if (norm(imag, 1.0) == 0.0) {
+        val exped = new DenseVector(real.data.map(scala.math.pow(_, exp)))
 
-      (evectors.t \ (evectors * diag(exped)).t).t
+        (evectors.t \ (evectors * diag(exped)).t).t
+      } else {
+        require(exp % 1 == 0, "If m has complex eigenvalues exp need to be Int")
+        powBySquaring(m, exp.toInt)
+      }
     }
   }
 

--- a/math/src/test/scala/breeze/linalg/LinearAlgebraTest.scala
+++ b/math/src/test/scala/breeze/linalg/LinearAlgebraTest.scala
@@ -733,6 +733,9 @@ class LinearAlgebraTest extends FunSuite with Checkers with Matchers with Double
     val X = DenseMatrix((.7, .2), (.3, .8))
     assert(mpow(X, 1) === X)
     assert(max(abs(mpow(X, .5) - DenseMatrix((.82426, 0.11716), (.17574, 0.88284)))) < 1E-5, mpow(X, .5))
+    // Test for matrix with complex eigenvalues
+    val X_complex_eig = DenseMatrix((2.0, 1.0), (-1.0, 2.0))
+    assert(mpow(X_complex_eig, 2) === DenseMatrix((3.0, 4.0), (-4.0, 3.0)))
   }
 
   test("diff test") {


### PR DESCRIPTION
Adding powBySquaring function which mpow uses when m has complex eigenvalues. 

This solution is needed since inv(m) currently doesn't support complex matrices.

I decided that I wanted to learn Scala, and that a good way of doing so could be to contribute to some open library a bit, and then I found breeze. So please bear with me if there are any beginner mistakes (I have a Python background).