### PR TITLE
Factor out DescriptiveStats.percentileInPlace

### DIFF
--- a/math/src/main/scala/breeze/stats/DescriptiveStats.scala
+++ b/math/src/main/scala/breeze/stats/DescriptiveStats.scala
@@ -518,12 +518,24 @@ object bincount extends UFunc {
 object DescriptiveStats {
 
   /**
-   * returns the estimate of the data at p * it.size, where p in [0,1]
+   * Returns the estimate of the data at p * it.size after copying and sorting, where p in [0,1].
    */
   def percentile(it: TraversableOnce[Double], p: Double) = {
     if (p > 1 || p < 0) throw new IllegalArgumentException("p must be in [0,1]")
     val arr = it.toArray
     Sorting.quickSort(arr)
+    percentileInPlace(arr, p)
+  }
+
+  /**
+    * Returns the estimate of a pre-sorted array at p * it.size, where p in [0,1].
+    * <p>
+    * Note:
+    * Result is invalid if the input array is not already sorted.
+    * </p>
+    */
+  def percentileInPlace(arr: Array[Double], p: Double) = {
+    if (p > 1 || p < 0) throw new IllegalArgumentException("p must be in [0,1]")
     // +1 so that the .5 == mean for even number of elements.
     val f = (arr.length + 1) * p
     val i = f.toInt


### PR DESCRIPTION
The percentile function always copies and sorts the input data, which provides good safety for the general case. This is inefficient, however, in cases where data already happens to be sorted or where the user wants to calculate a series of percentiles on a single dataset.

We factor out the sorting step and the percentile calculation step here and make a public percentileInPlace function that takes in a pre-sorted array so that users can opt in to the responsibility of array creation and sorting on their own.

Note that I'm relatively new to scala breeze, so very open to feeback on naming, documentation conventions, etc. If this simply doesn't fit in with the overall API you want to present to users, that's a perfectly fine outcome as well. Thanks for your work on this library!