### PR TITLE
Change image format from png to svg for travis-ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Breeze [![Build Status](https://travis-ci.org/scalanlp/breeze.png?branch=master)](https://travis-ci.org/scalanlp/breeze)
+# Breeze [![Build Status](https://travis-ci.org/scalanlp/breeze.svg?branch=master)](https://travis-ci.org/scalanlp/breeze)
 
 Breeze is a library for numerical processing. It aims to be generic, clean, and powerful without sacrificing (much) efficiency.
 


### PR DESCRIPTION
svg appears to be the standard badge format today, but this repo is still using png, which was the preferred option at the time the badge was added in d2c432e16c5f347488e24875ce61db36cf3b18e0.

svg will look sharper on high-resolution displays.