### PR TITLE
Fix dimension inconsistency in QR decomposition

### DIFF
--- a/math/src/main/scala/breeze/linalg/functions/qr.scala
+++ b/math/src/main/scala/breeze/linalg/functions/qr.scala
@@ -172,7 +172,15 @@ object qr extends UFunc {
       throw new IllegalArgumentException()
 
     // Handle mode that don't return Q
-    if (skipQ) (null, upperTriangular(A(0 until mn, ::)))
+    if (skipQ) {
+      // Upper triangle
+      cforRange(0 until mn) { i =>
+        cforRange(0 until min(i, A.cols)) { j =>
+          A(i, j) = 0.0
+        }
+      }
+      (null, A(0 until mn, ::))
+    }
     else {
       val Q =
         if (mode == CompleteQR && m > n) DenseMatrix.zeros[Double](m, m)
@@ -235,7 +243,15 @@ object qr extends UFunc {
       throw new IllegalArgumentException()
 
     // Handle mode that don't return Q
-    if (skipQ) (null, upperTriangular(A(0 until mn, ::)))
+    if (skipQ) {
+      // Upper triangle
+      cforRange(0 until mn) { i =>
+        cforRange(0 until min(i, A.cols)) { j =>
+          A(i, j) = 0.0f
+        }
+      }
+      (null, A(0 until mn, ::))
+    }
     else {
       val Q =
         if (mode == CompleteQR && m > n) DenseMatrix.zeros[Float](m, m)


### PR DESCRIPTION
When doing a reduced QR decomposition of A (m x n matrix) in QR, where Q is m x k and R is k x n, and k = min(m,n), if m < n, then R is not square.
When asking for justR, the matrix produced by upperTriangular is square, hence it is incorrect