### PR TITLE
Remove unnecessary type bounds from Vector fold and scan functions.

### DIFF
--- a/math/src/main/scala/breeze/linalg/Vector.scala
+++ b/math/src/main/scala/breeze/linalg/Vector.scala
@@ -111,11 +111,11 @@ trait Vector[@spec(Int, Double, Float) V] extends VectorLike[V, Vector[V]] {
 
   /** See [[scala.collection.mutable.ArrayOps.foldLeft]].
    */
-  def foldLeft[B >: V](z: B)(op: (B, V) => B): B = valuesIterator.foldLeft(z)(op)
+  def foldLeft[B](z: B)(op: (B, V) => B): B = valuesIterator.foldLeft(z)(op)
 
   /** See [[scala.collection.mutable.ArrayOps.foldRight]].
    */
-  def foldRight[B >: V](z: B)(op: (V, B) => B): B = valuesIterator.foldRight(z)(op)
+  def foldRight[B](z: B)(op: (V, B) => B): B = valuesIterator.foldRight(z)(op)
 
   /** See [[scala.collection.mutable.ArrayOps.reduce]].
    */
@@ -141,13 +141,13 @@ trait Vector[@spec(Int, Double, Float) V] extends VectorLike[V, Vector[V]] {
 
   /** See [[scala.collection.mutable.ArrayOps.scanLeft]].
    */
-  def scanLeft[B >: V](z: B)(op: (B, V) => B)(implicit cm1: ClassTag[B]): Vector[B] = {
+  def scanLeft[B](z: B)(op: (B, V) => B)(implicit cm1: ClassTag[B]): Vector[B] = {
     Vector[B](valuesIterator.scanLeft(z)(op).toArray)
   }
 
   /** See [[scala.collection.mutable.ArrayOps.scanRight]].
    */
-  def scanRight[B >: V](z: B)(op: (V, B) => B)(implicit cm1: ClassTag[B]): Vector[B] =
+  def scanRight[B](z: B)(op: (V, B) => B)(implicit cm1: ClassTag[B]): Vector[B] =
     Vector[B](valuesIterator.scanRight(z)(op).toArray)
 
   // </editor-fold>


### PR DESCRIPTION
This PR fixes #720 by removing unrequired type bounds in `foldLeft`, `foldRight`, `scanLeft` and `scanRight` for `Vector`.

The change compiles without error via `sbt compile` and `sbt test` passes all unit tests. Note: I did need to increase sbt memory to ~6GB or else I would occasionally have an OOM error during `sbt compile`. (This happens with just the unchanged repository though and I cannot see how it would be related to this set of changes).

Here is an example of the functionality working as expected:

```
scala> val v = DenseVector[Double](1, 2, 3, 4, 5)
v: breeze.linalg.DenseVector[Double] = DenseVector(1.0, 2.0, 3.0, 4.0, 5.0)

scala> v.foldLeft(false)((acc, v) => acc || (v > 4))
res5: Boolean = true
```

Here is an example of the same functionality failing if the change is not made:

```
scala> val v = DenseVector[Double](1, 2, 3, 4, 5)
v: DenseVector[Double] = DenseVector(1.0, 2.0, 3.0, 4.0, 5.0)

scala> v.foldLeft(false)((acc, v) => acc || (v > 4))
cmd4.sc:1: value || is not a member of AnyVal
val res4 = v.foldLeft(false)((acc, v) => acc || (v > 4))
                                             ^
Compilation Failed
```