### PR TITLE
FirstOrderMinimizer#defaultConvergenceCheck fails with negative function values

### DIFF
--- a/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
+++ b/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala
@@ -2,12 +2,11 @@ package breeze.optimize
 
 import breeze.linalg.norm
 import breeze.math.{MutableEnumeratedCoordinateField, MutableFiniteCoordinateField, NormedModule}
-import breeze.optimize.FirstOrderMinimizer.ConvergenceReason
+import breeze.optimize.FirstOrderMinimizer.ConvergenceCheck
 import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator}
 import breeze.util.Implicits._
 import breeze.util.SerializableLogging
 import org.apache.commons.math3.random.MersenneTwister
-import FirstOrderMinimizer.ConvergenceCheck
 
 /**
  *
@@ -254,7 +253,7 @@ object FirstOrderMinimizer {
     import space.normImpl
     ConvergenceCheck.fromPartialFunction[T] {
       case s: State[T, _, _]
-          if (norm(s.adjustedGradient) <= math.max(tolerance * (if (relative) s.adjustedValue else 1.0), 1E-8)) =>
+          if norm(s.adjustedGradient) <= math.max(tolerance * (if (relative) s.adjustedValue.abs else 1.0), 1E-8) =>
         GradientConverged
     }
   }

--- a/math/src/test/scala/breeze/optimize/FirstOrderMinimizerTest.scala
+++ b/math/src/test/scala/breeze/optimize/FirstOrderMinimizerTest.scala
@@ -7,7 +7,7 @@ class FirstOrderMinimizerTest extends FunSuite {
 
   test("default relative gradient convergence check for negative function values") {
     val value = -10
-    val gradient = (1E-7) * DenseVector.ones[Double](5)
+    val gradient = DenseVector.fill(5){1E-7}
     val convergenceCheck = FirstOrderMinimizer.defaultConvergenceCheck[DenseVector[Double]](100, 1E-5, relative = true)
     val state = FirstOrderMinimizer.State[DenseVector[Double], Any, Any](
       DenseVector.ones(5),

--- a/math/src/test/scala/breeze/optimize/FirstOrderMinimizerTest.scala
+++ b/math/src/test/scala/breeze/optimize/FirstOrderMinimizerTest.scala
@@ -1,0 +1,27 @@
+package breeze.optimize
+
+import breeze.linalg.DenseVector
+import org.scalatest.FunSuite
+
+class FirstOrderMinimizerTest extends FunSuite {
+
+  test("default relative gradient convergence check for negative function values") {
+    val value = -10
+    val gradient = (1E-7) * DenseVector.ones[Double](5)
+    val convergenceCheck = FirstOrderMinimizer.defaultConvergenceCheck[DenseVector[Double]](100, 1E-5, relative = true)
+    val state = FirstOrderMinimizer.State[DenseVector[Double], Any, Any](
+      DenseVector.ones(5),
+      value,
+      gradient,
+      value,
+      gradient,
+      8,
+      -1,
+      LBFGS.ApproximateInverseHessian[DenseVector[Double]](4),
+      ()
+    )
+    val checkResult = convergenceCheck.apply(state, convergenceCheck.initialInfo)
+    assert(checkResult.contains(FirstOrderMinimizer.GradientConverged))
+  }
+
+}


### PR DESCRIPTION
I noticed that the default convergence check for `FirstOrderMinimizer` does not use absolute value of the function, when doing a check for relative gradient. I think when minimizing functions that yield negative values at the current considered point, the tolerance for gradient norm always falls back to `1E-8`.

Fixed to use the absolute value of the optimized function. Could you please check if this could be merged?

EDIT: Seems the CI pipeline doesn't pass, but the tests passed locally for me.