### PR TITLE
Remove Scala 2.11 from Travis to fix build status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: xenial
 language: scala
 scala:
-  - 2.11.12
   - 2.12.8
   - 2.13.1
 jdk:


### PR DESCRIPTION
It's still in the `.sbt` files so one could reenable it more easily in case someone really needs it.