### PR TITLE
Issue 779/outer product with sparse vectors

### DIFF
--- a/math/src/test/scala/breeze/linalg/SparseVectorTest.scala
+++ b/math/src/test/scala/breeze/linalg/SparseVectorTest.scala
@@ -248,6 +248,25 @@ class SparseVectorTest extends FunSuite {
 
   }
 
+  test("SparseVector * DenseVector Transposed OpMulMatrix") {
+    val sv = SparseVector(3)(0 -> 1, 1 -> 2, 2 -> 3)
+
+    val dv = DenseVector(5, 7, 11)
+
+    val expected = CSCMatrix.zeros[Int](3, 3)
+    expected(0, 0) = 5
+    expected(0, 1) = 7
+    expected(0, 2) = 11
+    expected(1, 0) = 10
+    expected(1, 1) = 14
+    expected(1, 2) = 22
+    expected(2, 0) = 15
+    expected(2, 1) = 21
+    expected(2, 2) = 33
+
+    assert(sv * dv.t === expected)
+  }
+
   test("Transpose Complex") {
     val a = SparseVector.zeros[Complex](4)
     a(1) = Complex(1, 1)
@@ -401,14 +420,12 @@ abstract class SparseVectorPropertyTestBase[T: ClassTag: Zero: Semiring]
   }
 }
 
-
 class SparseVectorOps_DoubleTest
     extends SparseVectorPropertyTestBase[Double]
     with DoubleValuedTensorSpaceTestBase[SparseVector[Double], Int] {
   val space = SparseVector.space[Double]
   def genScalar: Arbitrary[Double] = RandomInstanceSupport.genReasonableDouble
 }
-
 
 class SparseVectorOps_FloatTest extends SparseVectorPropertyTestBase[Float] {
   val space = SparseVector.space[Float]
@@ -417,7 +434,6 @@ class SparseVectorOps_FloatTest extends SparseVectorPropertyTestBase[Float] {
   def genScalar: Arbitrary[Float] = Arbitrary { RandomInstanceSupport.genReasonableDouble.arbitrary.map(_.toFloat) }
 
 }
-
 
 class SparseVectorOps_IntTest extends SparseVectorPropertyTestBase[Int] {
   val space = SparseVector.space[Int]

--- a/math/src/test/scala/breeze/linalg/SparseVectorTest.scala
+++ b/math/src/test/scala/breeze/linalg/SparseVectorTest.scala
@@ -267,6 +267,25 @@ class SparseVectorTest extends FunSuite {
     assert(sv * dv.t === expected)
   }
 
+  test("DenseVector * SparseVector Transposed OpMulMatrix") {
+    val sv = SparseVector(3)(0 -> 1, 1 -> 2, 2 -> 3)
+
+    val dv = DenseVector(5, 7, 11)
+
+    val expected = CSCMatrix.zeros[Int](3, 3)
+    expected(0, 0) = 5
+    expected(0, 1) = 10
+    expected(0, 2) = 15
+    expected(1, 0) = 7
+    expected(1, 1) = 14
+    expected(1, 2) = 21
+    expected(2, 0) = 11
+    expected(2, 1) = 22
+    expected(2, 2) = 33
+
+    assert(dv * sv.t === expected)
+  }
+
   test("Transpose Complex") {
     val a = SparseVector.zeros[Complex](4)
     a(1) = Complex(1, 1)


### PR DESCRIPTION
First version of the implementation of outer product between `DenseVector` and `Transposed SparseVector`. Should close #779 

I am very welcome to reviews, I was not sure in which trait I should put the operations implementations.

I tried to mutualize these 2 operations implementations with macro, without success.