### PR TITLE
breeze-718: remove hard coded "maximize" in LinearProgram.Problem.toString

### DIFF
--- a/math/src/test/scala/breeze/optimize/linear/LinearProgramTest.scala
+++ b/math/src/test/scala/breeze/optimize/linear/LinearProgramTest.scala
@@ -80,4 +80,43 @@ class LinearProgramTest extends FunSuite {
   }
  */
 
+  test("maximize with solve method") {
+    val lp = new LinearProgram
+    import lp._
+    val x0 = Real()
+    val x1 = Real()
+
+    val max = maximize(x0 + x1)
+      .subjectTo(x0  <= 20)
+      .subjectTo(x1 <= 30)
+
+    val res = max.solve
+    println(max)
+    println(res.result)
+    assert(norm(res.result - DenseVector(20.0, 30.0), 2) < 1E-4)
+
+    assertThrows[AssertionError](minimize(max))
+
+  }
+
+  test("minimize with solve method") {
+    val lp = new LinearProgram
+    import lp._
+    val x0 = Real()
+    val x1 = Real()
+
+    val min = minimize(x0 + x1)
+      .subjectTo(x0  >= 20)
+      .subjectTo(x1 >= 30)
+
+    val res = min.solve
+    println(min)
+    println(res.result)
+
+    assert(norm(res.result - DenseVector(20.0, 30.0), 2) < 1E-4)
+
+    assertThrows[AssertionError](maximize(min))
+
+  }
+
 }


### PR DESCRIPTION
### Description
This PR should close #718 

- A method `goal` was added into the trait `Problem`. 
  ```scala
  sealed trait Problem {
    outer =>
    def goal: Option[GoalType] = None
    ...
  }
  ```
- Two methods (`maximize` and `minimize`) were added into the class `LinearProgram`
  ```scala
  def minimize(expression: Expression): Problem
  def maximize(expression: Expression): Problem
  ```

  The two new methods will override the method `goal` during the instantiation of a Problem object. 
  When we call `Problem.toString`, the output of `goal` will be used instead of the hard coded "maximize"

- [A check was added](https://github.com/scalanlp/breeze/compare/master...qxzzxq:breeze-718?expand=1#diff-3618428c529431e64aec48d8a14277cbR295) to prevent from calling `maximize()` on a minimization problem

- A method `solve` was implemented in the trait `Problem`. Il will invoke the corresponding method according to the value of `goal`

### Example
```scala
val lp = new LinearProgram()
import lp._

val x0 = Real()
val x1 = Real()

val min = minimize(x0 + x1)
  .subjectTo(x0 >= 20)
  .subjectTo(x1 >= 30)

println(min.toString)
// minimize    x_0 + x_1
// subject to  x_0 >= 20.0
//             x_1 >= 30.0

min.solve  // this equals to minimize(min)

maximize(min)  // this will throw an exception

```