### PR TITLE
Minor upgrades: scala 2.13.1 to 2.13.3, sbt 1.3.7 to 1.3.13

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,7 +10,7 @@ object Common {
     }
   }
 
-  val buildCrossScalaVersions = Seq("2.12.10", "2.13.1")
+  val buildCrossScalaVersions = Seq("2.12.10", "2.13.3")
 
   lazy val buildScalaVersion = buildCrossScalaVersions.head
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.7
+sbt.version=1.3.13


### PR DESCRIPTION
The compiler warnings remain the same between pre and post upgrade.