### PR TITLE
upgrade to ScalaCheck 1.15.1

### DIFF
--- a/math/src/test/scala/breeze/math/MutableModuleTestBase.scala
+++ b/math/src/test/scala/breeze/math/MutableModuleTestBase.scala
@@ -1,6 +1,6 @@
 package breeze.math
 
-import org.scalacheck.Prop.BooleanOperators
+import org.scalacheck.Prop.propBoolean
 import org.scalacheck._
 import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.Checkers

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -22,7 +22,7 @@ object Common {
     javacOptions ++= Seq("-target", "1.7", "-source", "1.7"),
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
     libraryDependencies ++= Seq(
-      "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
+      "org.scalacheck" %% "scalacheck" % "1.15.1" % "test",
       "org.scalatest" %% "scalatest" % "3.0.8" % "test",
    //   "org.scala-lang.modules" %% "scala-collection-compat" % "1.0.0"
     ),


### PR DESCRIPTION
one tiny source adjustment needed, to adapt to typelevel/scalacheck#667

it would be convenient for me in the Scala community build if this were merged