### PR TITLE
Add method to multiply dense vectors with CSC matrices

### DIFF
--- a/math/src/main/codegen/breeze/linalg/operators/CSCMatrixOps.scala
+++ b/math/src/main/codegen/breeze/linalg/operators/CSCMatrixOps.scala
@@ -57,16 +57,17 @@ trait CSCMatrixOps extends CSCMatrixOps_Ring { this: CSCMatrix.type =>
     }
 
   implicit def canMulDVt_CSC_eq_DVt[T](
-      implicit op: OpMulMatrix.Impl2[CSCMatrix[T], CSCMatrix[T], CSCMatrix[T]],
+      implicit op: OpMulMatrix.Impl2[DenseMatrix[T], CSCMatrix[T], DenseMatrix[T]],
       zero: Zero[T],
       ct: ClassTag[T]): OpMulMatrix.Impl2[Transpose[DenseVector[T]], CSCMatrix[T], Transpose[DenseVector[T]]] =
     new OpMulMatrix.Impl2[Transpose[DenseVector[T]], CSCMatrix[T], Transpose[DenseVector[T]]] {
       def apply(v: Transpose[DenseVector[T]], v2: CSCMatrix[T]): Transpose[DenseVector[T]] = {
         require(v2.rows == v.inner.length)
-        val csc = v.inner.asCscRow
-        val cscr = op(csc, v2)
 
-        new Transpose[DenseVector[T]](DenseVector.fromCSCMatrix(cscr))
+        val dm = v.inner.toDenseMatrix
+        val multiplied = op(dm, v2)
+
+        new Transpose[DenseVector[T]](multiplied.toDenseVector)
 
       }
     }

--- a/math/src/main/codegen/breeze/linalg/operators/CSCMatrixOps.scala
+++ b/math/src/main/codegen/breeze/linalg/operators/CSCMatrixOps.scala
@@ -56,6 +56,21 @@ trait CSCMatrixOps extends CSCMatrixOps_Ring { this: CSCMatrix.type =>
       }
     }
 
+  implicit def canMulDVt_CSC_eq_DVt[T](
+      implicit op: OpMulMatrix.Impl2[CSCMatrix[T], CSCMatrix[T], CSCMatrix[T]],
+      zero: Zero[T],
+      ct: ClassTag[T]): OpMulMatrix.Impl2[Transpose[DenseVector[T]], CSCMatrix[T], Transpose[DenseVector[T]]] =
+    new OpMulMatrix.Impl2[Transpose[DenseVector[T]], CSCMatrix[T], Transpose[DenseVector[T]]] {
+      def apply(v: Transpose[DenseVector[T]], v2: CSCMatrix[T]): Transpose[DenseVector[T]] = {
+        require(v2.rows == v.inner.length)
+        val csc = v.inner.asCscRow
+        val cscr = op(csc, v2)
+
+        new Transpose[DenseVector[T]](DenseVector.fromCSCMatrix(cscr))
+
+      }
+    }
+
   @expand
   @expand.valify
   implicit def csc_OpNeg[@expand.args(Int, Double, Float, Long) T]: OpNeg.Impl[CSCMatrix[T], CSCMatrix[T]] = {

--- a/math/src/test/scala/breeze/linalg/DenseVectorTest.scala
+++ b/math/src/test/scala/breeze/linalg/DenseVectorTest.scala
@@ -589,6 +589,23 @@ class DenseVectorTest extends FunSuite with Checkers {
       assert(fromNew === slice)
     }
   }
+
+  test("#715 - transpose DV * CSCMatrix") {
+   val dv = DenseVector(1,2,3,4)
+
+    val csc = CSCMatrix.zeros[Int](4, 4)
+    csc(1, 1) = 1
+    csc(1, 2) = 2
+    csc(2, 1) = 2
+    csc(2, 2) = 4
+
+    val multiplied = dv.t * csc
+
+    val expected = DenseVector(0,8,16,0).t
+
+    assert(multiplied == expected)
+  }
+
 }
 
 abstract class DenseVectorPropertyTestBase[T: ClassTag] extends TensorSpaceTestBase[DenseVector[T], Int, T] {


### PR DESCRIPTION
Hi, I saw this issue https://github.com/scalanlp/breeze/issues/715 and thought I'd have a go seeing as it's a good first issue (over 1 year old!).

I've copied the style of code around the repo and lightly cloned this test: "SparseVector * CSCMatrix Lifted OpMulMatrix & Transpose" to validate the matrix multiplication is correct for DenseVectors.

To allow the multiplication I've extracted 2 conversions (DenseVector to CSCMatrix and CSCMatrix to DenseVector - this latter one has an assertion inside that the Matrix has just 1 row), which are public.

Do let me know if there is more testing / other changes required.