### PR TITLE
Eliminate cycle in DenseVector/HasOps initialization.

### DIFF
--- a/math/src/main/scala/breeze/linalg/DenseVector.scala
+++ b/math/src/main/scala/breeze/linalg/DenseVector.scala
@@ -15,6 +15,7 @@ package breeze.linalg
  limitations under the License.
  */
 
+
 import scala.{specialized => spec}
 import breeze.generic._
 import breeze.linalg.support._
@@ -246,8 +247,7 @@ class DenseVector[@spec(Double, Int, Float, Long) V](
   }
 
   /** Returns true if this overlaps any content with the other vector */
-  private[linalg] def overlaps(other: DenseVector[V]): Boolean =
-    (this.data eq other.data) && RangeUtils.overlaps(footprint, other.footprint)
+  private[linalg] def overlaps(other: DenseVector[V]): Boolean = (this.data eq other.data) && RangeUtils.overlaps(footprint, other.footprint)
 
   private def footprint: Range = {
     if (length == 0) {
@@ -501,6 +501,7 @@ object DenseVector extends VectorConstructors[DenseVector] {
 
   implicit def DV_scalarOf[T]: ScalarOf[DenseVector[T], T] = ScalarOf.dummy
 
+
   class CanZipMapValuesDenseVector[@spec(Double, Int, Float, Long) V, @spec(Int, Double) RV: ClassTag]
       extends CanZipMapValues[DenseVector[V], V, RV, DenseVector[RV]] {
     def create(length: Int) = DenseVector(new Array[RV](length))
@@ -545,6 +546,7 @@ object DenseVector extends VectorConstructors[DenseVector] {
   }
 
   implicit def zipMapKV[V, R: ClassTag]: CanZipMapKeyValuesDenseVector[V, R] = new CanZipMapKeyValuesDenseVector[V, R]
+
 
   // this produces bad spaces for builtins (inefficient because of bad implicit lookup)
   implicit def space[E](

--- a/math/src/main/scala/breeze/linalg/operators/DenseVector_DoubleOps.scala
+++ b/math/src/main/scala/breeze/linalg/operators/DenseVector_DoubleOps.scala
@@ -7,6 +7,10 @@ import dev.ludovic.netlib.BLAS.{getInstance => blas}
 
 trait DenseVector_DoubleOps extends DenseVectorExpandOps {
 
+  // This takes higher precedence than [[DenseVector.canCopyDenseVector]] to avoid deadlock in
+  // static initialization. See comment on [[DenseVectorDeps]].
+  import DenseVectorDeps.canCopyDenseVector
+
   // TODO: try deleting (axpy)
   implicit val impl_OpAdd_InPlace_DV_DV_Double: OpAdd.InPlaceImpl2[DenseVector[Double], DenseVector[Double]] = {
     new OpAdd.InPlaceImpl2[DenseVector[Double], DenseVector[Double]] {
@@ -39,13 +43,16 @@ trait DenseVector_DoubleOps extends DenseVectorExpandOps {
     }
 
   }
-  implicitly[TernaryUpdateRegistry[Vector[Double], Double, Vector[Double], scaleAdd.type]].register(impl_scaleAdd_InPlace_DV_T_DV_Double)
+  implicitly[TernaryUpdateRegistry[Vector[Double], Double, Vector[Double], scaleAdd.type]]
+    .register(impl_scaleAdd_InPlace_DV_T_DV_Double)
 
   // TODO: try deleting? (pure)
-  implicit val impl_OpAdd_DV_DV_eq_DV_Double: OpAdd.Impl2[DenseVector[Double], DenseVector[Double], DenseVector[Double]] = {
+  implicit val impl_OpAdd_DV_DV_eq_DV_Double
+    : OpAdd.Impl2[DenseVector[Double], DenseVector[Double], DenseVector[Double]] = {
     pureFromUpdate(implicitly, implicitly)
   }
-  implicitly[BinaryRegistry[Vector[Double], Vector[Double], OpAdd.type, Vector[Double]]].register(impl_OpAdd_DV_DV_eq_DV_Double)
+  implicitly[BinaryRegistry[Vector[Double], Vector[Double], OpAdd.type, Vector[Double]]]
+    .register(impl_OpAdd_DV_DV_eq_DV_Double)
 
   implicit val impl_OpSub_InPlace_DV_DV_Double: OpSub.InPlaceImpl2[DenseVector[Double], DenseVector[Double]] = {
     new OpSub.InPlaceImpl2[DenseVector[Double], DenseVector[Double]] {
@@ -58,10 +65,12 @@ trait DenseVector_DoubleOps extends DenseVectorExpandOps {
   }
 
   // TODO: try removing
-  implicit val impl_OpSub_DV_DV_eq_DV_Double: OpSub.Impl2[DenseVector[Double], DenseVector[Double], DenseVector[Double]] = {
+  implicit val impl_OpSub_DV_DV_eq_DV_Double
+    : OpSub.Impl2[DenseVector[Double], DenseVector[Double], DenseVector[Double]] = {
     pureFromUpdate(implicitly, implicitly)
   }
-  implicitly[BinaryRegistry[Vector[Double], Vector[Double], OpSub.type, Vector[Double]]].register(impl_OpSub_DV_DV_eq_DV_Double)
+  implicitly[BinaryRegistry[Vector[Double], Vector[Double], OpSub.type, Vector[Double]]]
+    .register(impl_OpSub_DV_DV_eq_DV_Double)
 
   implicit object canDotD extends OpMulInner.Impl2[DenseVector[Double], DenseVector[Double], Double] {
     def apply(a: DenseVector[Double], b: DenseVector[Double]) = {
@@ -120,8 +129,12 @@ trait DenseVector_DoubleOps extends DenseVectorExpandOps {
 
 trait DenseVector_FloatOps extends DenseVectorExpandOps {
 
+  // This takes higher precedence than [[DenseVector.canCopyDenseVector]] to avoid deadlock in
+  // static initialization. See comment on [[DenseVectorDeps]].
+  import DenseVectorDeps.canCopyDenseVector
+
   implicit object impl_scaledAdd_InPlace_DV_S_DV_Float
-    extends scaleAdd.InPlaceImpl3[DenseVector[Float], Float, DenseVector[Float]]
+      extends scaleAdd.InPlaceImpl3[DenseVector[Float], Float, DenseVector[Float]]
       with Serializable {
     def apply(y: DenseVector[Float], a: Float, x: DenseVector[Float]): Unit = {
       require(x.length == y.length, s"Vectors must have same length")
@@ -162,7 +175,8 @@ trait DenseVector_FloatOps extends DenseVectorExpandOps {
   implicit val impl_OpAdd_DV_DV_eq_DV_Float: OpAdd.Impl2[DenseVector[Float], DenseVector[Float], DenseVector[Float]] = {
     pureFromUpdate(implicitly, implicitly)
   }
-  implicitly[BinaryRegistry[Vector[Float], Vector[Float], OpAdd.type, Vector[Float]]].register(impl_OpAdd_DV_DV_eq_DV_Float)
+  implicitly[BinaryRegistry[Vector[Float], Vector[Float], OpAdd.type, Vector[Float]]]
+    .register(impl_OpAdd_DV_DV_eq_DV_Float)
 
   implicit val impl_OpSub_InPlace_DV_DV_Float: OpSub.InPlaceImpl2[DenseVector[Float], DenseVector[Float]] = {
     new OpSub.InPlaceImpl2[DenseVector[Float], DenseVector[Float]] {
@@ -176,10 +190,11 @@ trait DenseVector_FloatOps extends DenseVectorExpandOps {
   implicit val impl_OpSub_DV_DV_eq_DV_Float: OpSub.Impl2[DenseVector[Float], DenseVector[Float], DenseVector[Float]] = {
     pureFromUpdate(implicitly, implicitly)
   }
-  implicitly[BinaryRegistry[Vector[Float], Vector[Float], OpSub.type, Vector[Float]]].register(impl_OpSub_DV_DV_eq_DV_Float)
+  implicitly[BinaryRegistry[Vector[Float], Vector[Float], OpSub.type, Vector[Float]]]
+    .register(impl_OpSub_DV_DV_eq_DV_Float)
 
   implicit val impl_OpMulInner_DV_DV_eq_S_Float
-  : breeze.linalg.operators.OpMulInner.Impl2[DenseVector[Float], DenseVector[Float], Float] = {
+    : breeze.linalg.operators.OpMulInner.Impl2[DenseVector[Float], DenseVector[Float], Float] = {
     new breeze.linalg.operators.OpMulInner.Impl2[DenseVector[Float], DenseVector[Float], Float] {
       def apply(a: DenseVector[Float], b: DenseVector[Float]) = {
         require(a.length == b.length, s"Vectors must have same length")

--- a/math/src/main/scala/breeze/linalg/operators/DenseVector_DoubleOps.scala
+++ b/math/src/main/scala/breeze/linalg/operators/DenseVector_DoubleOps.scala
@@ -43,16 +43,13 @@ trait DenseVector_DoubleOps extends DenseVectorExpandOps {
     }
 
   }
-  implicitly[TernaryUpdateRegistry[Vector[Double], Double, Vector[Double], scaleAdd.type]]
-    .register(impl_scaleAdd_InPlace_DV_T_DV_Double)
+  implicitly[TernaryUpdateRegistry[Vector[Double], Double, Vector[Double], scaleAdd.type]].register(impl_scaleAdd_InPlace_DV_T_DV_Double)
 
   // TODO: try deleting? (pure)
-  implicit val impl_OpAdd_DV_DV_eq_DV_Double
-    : OpAdd.Impl2[DenseVector[Double], DenseVector[Double], DenseVector[Double]] = {
+  implicit val impl_OpAdd_DV_DV_eq_DV_Double: OpAdd.Impl2[DenseVector[Double], DenseVector[Double], DenseVector[Double]] = {
     pureFromUpdate(implicitly, implicitly)
   }
-  implicitly[BinaryRegistry[Vector[Double], Vector[Double], OpAdd.type, Vector[Double]]]
-    .register(impl_OpAdd_DV_DV_eq_DV_Double)
+  implicitly[BinaryRegistry[Vector[Double], Vector[Double], OpAdd.type, Vector[Double]]].register(impl_OpAdd_DV_DV_eq_DV_Double)
 
   implicit val impl_OpSub_InPlace_DV_DV_Double: OpSub.InPlaceImpl2[DenseVector[Double], DenseVector[Double]] = {
     new OpSub.InPlaceImpl2[DenseVector[Double], DenseVector[Double]] {
@@ -65,12 +62,10 @@ trait DenseVector_DoubleOps extends DenseVectorExpandOps {
   }
 
   // TODO: try removing
-  implicit val impl_OpSub_DV_DV_eq_DV_Double
-    : OpSub.Impl2[DenseVector[Double], DenseVector[Double], DenseVector[Double]] = {
+  implicit val impl_OpSub_DV_DV_eq_DV_Double: OpSub.Impl2[DenseVector[Double], DenseVector[Double], DenseVector[Double]] = {
     pureFromUpdate(implicitly, implicitly)
   }
-  implicitly[BinaryRegistry[Vector[Double], Vector[Double], OpSub.type, Vector[Double]]]
-    .register(impl_OpSub_DV_DV_eq_DV_Double)
+  implicitly[BinaryRegistry[Vector[Double], Vector[Double], OpSub.type, Vector[Double]]].register(impl_OpSub_DV_DV_eq_DV_Double)
 
   implicit object canDotD extends OpMulInner.Impl2[DenseVector[Double], DenseVector[Double], Double] {
     def apply(a: DenseVector[Double], b: DenseVector[Double]) = {
@@ -134,7 +129,7 @@ trait DenseVector_FloatOps extends DenseVectorExpandOps {
   import DenseVectorDeps.canCopyDenseVector
 
   implicit object impl_scaledAdd_InPlace_DV_S_DV_Float
-      extends scaleAdd.InPlaceImpl3[DenseVector[Float], Float, DenseVector[Float]]
+    extends scaleAdd.InPlaceImpl3[DenseVector[Float], Float, DenseVector[Float]]
       with Serializable {
     def apply(y: DenseVector[Float], a: Float, x: DenseVector[Float]): Unit = {
       require(x.length == y.length, s"Vectors must have same length")
@@ -175,8 +170,7 @@ trait DenseVector_FloatOps extends DenseVectorExpandOps {
   implicit val impl_OpAdd_DV_DV_eq_DV_Float: OpAdd.Impl2[DenseVector[Float], DenseVector[Float], DenseVector[Float]] = {
     pureFromUpdate(implicitly, implicitly)
   }
-  implicitly[BinaryRegistry[Vector[Float], Vector[Float], OpAdd.type, Vector[Float]]]
-    .register(impl_OpAdd_DV_DV_eq_DV_Float)
+  implicitly[BinaryRegistry[Vector[Float], Vector[Float], OpAdd.type, Vector[Float]]].register(impl_OpAdd_DV_DV_eq_DV_Float)
 
   implicit val impl_OpSub_InPlace_DV_DV_Float: OpSub.InPlaceImpl2[DenseVector[Float], DenseVector[Float]] = {
     new OpSub.InPlaceImpl2[DenseVector[Float], DenseVector[Float]] {
@@ -190,11 +184,10 @@ trait DenseVector_FloatOps extends DenseVectorExpandOps {
   implicit val impl_OpSub_DV_DV_eq_DV_Float: OpSub.Impl2[DenseVector[Float], DenseVector[Float], DenseVector[Float]] = {
     pureFromUpdate(implicitly, implicitly)
   }
-  implicitly[BinaryRegistry[Vector[Float], Vector[Float], OpSub.type, Vector[Float]]]
-    .register(impl_OpSub_DV_DV_eq_DV_Float)
+  implicitly[BinaryRegistry[Vector[Float], Vector[Float], OpSub.type, Vector[Float]]].register(impl_OpSub_DV_DV_eq_DV_Float)
 
   implicit val impl_OpMulInner_DV_DV_eq_S_Float
-    : breeze.linalg.operators.OpMulInner.Impl2[DenseVector[Float], DenseVector[Float], Float] = {
+  : breeze.linalg.operators.OpMulInner.Impl2[DenseVector[Float], DenseVector[Float], Float] = {
     new breeze.linalg.operators.OpMulInner.Impl2[DenseVector[Float], DenseVector[Float], Float] {
       def apply(a: DenseVector[Float], b: DenseVector[Float]) = {
         require(a.length == b.length, s"Vectors must have same length")


### PR DESCRIPTION
Addresses https://github.com/scalanlp/breeze/issues/825. I'm not sure if it fully eliminates any cycles, but it removes the observed deadlock in our code. 