### PR TITLE
Updating Log4j version to 2.17.0 because of CVE-2021-45105 vulnerability.

### DIFF
--- a/math/build.sbt
+++ b/math/build.sbt
@@ -13,9 +13,9 @@ libraryDependencies ++= Seq(
 //  ("com.chuusai" %% "shapeless" % "2.3.3").withDottyCompat(scalaVersion.value),
   "org.slf4j" % "slf4j-api" % "1.7.5",
   ("org.typelevel" %% "spire" % "0.17.0").cross(CrossVersion.for3Use2_13),
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.0-beta9" % "test",
-  "org.apache.logging.log4j" % "log4j-core" % "2.0-beta9" % "test",
-  "org.apache.logging.log4j" % "log4j-api" % "2.0-beta9" % "test",
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.17.0" % "test",
+  "org.apache.logging.log4j" % "log4j-core" % "2.17.0" % "test",
+  "org.apache.logging.log4j" % "log4j-api" % "2.17.0" % "test",
 //  ("org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1").withDottyCompat(scalaVersion.value)
 )
 


### PR DESCRIPTION
Update Log4j version to 2.17.0
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105
