### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/math/build.sbt
+++ b/math/build.sbt
@@ -13,9 +13,9 @@ libraryDependencies ++= Seq(
 //  ("com.chuusai" %% "shapeless" % "2.3.3").withDottyCompat(scalaVersion.value),
   "org.slf4j" % "slf4j-api" % "1.7.5",
   ("org.typelevel" %% "spire" % "0.17.0").cross(CrossVersion.for3Use2_13),
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.17.0" % "test",
-  "org.apache.logging.log4j" % "log4j-core" % "2.17.0" % "test",
-  "org.apache.logging.log4j" % "log4j-api" % "2.17.0" % "test",
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.17.1" % "test",
+  "org.apache.logging.log4j" % "log4j-core" % "2.17.1" % "test",
+  "org.apache.logging.log4j" % "log4j-api" % "2.17.1" % "test",
 //  ("org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1").withDottyCompat(scalaVersion.value)
 )
 


### PR DESCRIPTION
Hello new Patch!
Update log4j to 2.17.1 to address CVE-2021-44832.
https://nvd.nist.gov/vuln/detail/CVE-2021-44832