### PR TITLE
fix for #850: transpose-slice-multiply crash

### DIFF
--- a/math/src/main/codegen/breeze/linalg/operators/DenseMatrixOps.scala
+++ b/math/src/main/codegen/breeze/linalg/operators/DenseMatrixOps.scala
@@ -301,9 +301,9 @@ trait DenseMatrixMultiplyOps extends DenseMatrixExpandedOps with DenseMatrixMult
 
       // if we have a weird stride...
       val a: DenseMatrix[Double] =
-        if (_a.majorStride < math.max(if (_a.isTranspose) _a.cols else _a.rows, 1)) _a.copy else _a
+        if (_a.majorStride > math.max(if (_a.isTranspose) _a.cols else _a.rows, 1)) _a.copy else _a
       val b: DenseMatrix[Double] =
-        if (_b.majorStride < math.max(if (_b.isTranspose) _b.cols else _b.rows, 1)) _b.copy else _b
+        if (_b.majorStride > math.max(if (_b.isTranspose) _b.cols else _b.rows, 1)) _b.copy else _b
 
       blas.dgemm(
         transposeString(a),

--- a/math/src/test/scala/breeze/linalg/DenseMatrixTest.scala
+++ b/math/src/test/scala/breeze/linalg/DenseMatrixTest.scala
@@ -846,6 +846,17 @@ class DenseMatrixTest extends AnyFunSuite with Checkers with DoubleImplicits wit
     assert(sm == sm.copy)
   }
 
+  test("#850 - transpose slice multiply bug") {
+    val Jɴ = DenseMatrix( (0.75,  -0.25), (-0.25,  0.75))
+    val matB = DenseMatrix(
+      (67.0, 33.0),
+      (69.0, 78.0),
+      (93.0, 57.0)
+    ).t
+    val B = matB(::, 1 until matB.cols)
+    Jɴ * B      // should not crash
+  }
+
 }
 
 trait MatrixTestUtils {

--- a/math/src/test/scala/breeze/linalg/TextOperationsTest.scala
+++ b/math/src/test/scala/breeze/linalg/TextOperationsTest.scala
@@ -7,9 +7,10 @@ import org.scalatest.funsuite.AnyFunSuite
  * Created by Luca Puggini: lucapuggio@gmail.com on 19/02/16.
  */
 class TextOperationsTest extends AnyFunSuite {
+  System.err.println(new File(".").getAbsolutePath)
   test("csvread and String2File methods") {
     // A csv file can be read both using the java File function and the toFile method of the string class
-    val file_path = if (new File(".").getAbsolutePath.endsWith("math/.")) {
+    val file_path = if (new File(".").getAbsolutePath.replace('\\', '/').endsWith("math/.")) {
       "src/test/resources/glass_data.txt"
     } else {
       "./math/src/test/resources/glass_data.txt"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ object Common {
     }
   }
 
-  val buildCrossScalaVersions = Seq("3.1.3", "2.12.15", "2.13.8")
+  val buildCrossScalaVersions = Seq("3.4.2", "2.12.19", "2.13.14")
 
   lazy val buildScalaVersion = buildCrossScalaVersions.head
 


### PR DESCRIPTION
The fix consisted of changing the comparison operator from `<` to `>` here:
diff math/src/main/codegen/breeze/linalg/operators/DenseMatrixOps.scala
```scala
       // if we have a weird stride...
       val a: DenseMatrix[Double] =
-        if (_a.majorStride < math.max(if (_a.isTranspose) _a.cols else _a.rows, 1)) _a.copy else _a
+        if (_a.majorStride > math.max(if (_a.isTranspose) _a.cols else _a.rows, 1)) _a.copy else _a
       val b: DenseMatrix[Double] =
-        if (_b.majorStride < math.max(if (_b.isTranspose) _b.cols else _b.rows, 1)) _b.copy else _b
+        if (_b.majorStride > math.max(if (_b.isTranspose) _b.cols else _b.rows, 1)) _b.copy else _b
```
The problem occurs when `majorStride` is too big rather than too small, so a `copy` is needed.
This might represent a performance improvement, on average, if it results in fewer calls to `_.copy`.

added a test to math/src/test/scala/breeze/linalg/DenseMatrixTest.scala
 ```scala
+  test("#850 - transpose slice multiply bug") {
+    val Jɴ = DenseMatrix( (0.75,  -0.25), (-0.25,  0.75))
+    val matB = DenseMatrix(
+      (67.0, 33.0),
+      (69.0, 78.0),
+      (93.0, 57.0)
+    ).t
+    val B = matB(::, 1 until matB.cols)
+    Jɴ * B      // should not crash
+  }
```

Also fixed a test that was failing in `Windows` due to a hardwired `/` path separator: `math/src/test/scala/breeze/linalg/TextOperationsTest.scala`
Fixed it by converting `\\` to '/' to find the correct relative path to  the resource file.

~~Upgraded the `sbt` version because `sbt` was crashing.~~

Upgraded scala versions.
```
diff --git a/project/Build.scala b/project/Build.scala
-  val buildCrossScalaVersions = Seq("3.1.3", "2.12.15", "2.13.8")
+  val buildCrossScalaVersions = Seq("3.4.2", "2.12.19", "2.13.14")
```

One test was failing on my system before I made any modifications, and is still failing now, so not sure what that's about.
```
[info] ProjectedQuasiNewtonTest:
[info] - optimize a simple multivariate gaussian (366 milliseconds)
[info] - optimize a simple multivariate gaussian with projection (136 milliseconds)
[info] - optimize a simple multivariate gaussian with l2 regularization (75 milliseconds)
[info] - optimize a complicated function without projection (393 milliseconds)
[info] - simple linear solve without projection (50 milliseconds)
L1 projection iter 67
[info] - simple linear solve with L1 projection compared to Octave *** FAILED *** (134 milliseconds)
[info]   1.1197254381828163E-4 was not less than 1.0E-4 (ProjectedQuasiNewtonTest.scala:221)
```